### PR TITLE
Update task to start server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Cadet is the web application powering Source Academy.
 
 Install Elixir dependencies
 
-    mix deps get
+    mix deps.get
 
 Initialise Development Database
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install frontend dependencies
 
 Run the server in your local machine
 
-    mix phx server
+    mix cadet.server
 
 ## License
 


### PR DESCRIPTION
ec00301: Previously, using phx server would raise error:
```** (Mix) The task "phx" could not be found```
([cadet.server runs phx.server](https://github.com/source-academy/cadet/blob/ad111c720ce3d76e7290105f85b74383cc86b52d/mix.exs#L77))

038a1cb: Also, following command had typo (space instead of dot),
```mix deps get```
([relevant mix docs](https://hexdocs.pm/mix/Mix.Tasks.Deps.Get.html))