### PR TITLE
Fix arc tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -26,3 +26,5 @@ config :cadet, Cadet.Repo,
 config :cadet, Cadet.Auth.Guardian,
   issuer: "cadet",
   secret_key: "4ZxeVrSvCJlmndrFL7tBpnZsTc/rOQygVIyscAMY1oKKzkKi7hkjXl9F1f28Jap8"
+
+config :arc, definition: Arc.Storage.Local

--- a/test/cadet/course/material_test.exs
+++ b/test/cadet/course/material_test.exs
@@ -5,7 +5,7 @@ defmodule Cadet.Course.MaterialTest do
 
   valid_changesets Material do
     %{name: "Lecture Notes", description: "This is lecture notes"}
-    %{name: "File", file: "test/fixtures/upload.txt"}
+    %{name: "File", file: build_upload("test/fixtures/upload.txt", "text/plain")}
   end
 
   invalid_changesets Material do

--- a/test/support/changeset_case.ex
+++ b/test/support/changeset_case.ex
@@ -21,7 +21,7 @@ defmodule Cadet.ChangesetCase do
   end
 
   def build_upload(path, content_type \\ "image\png") do
-    %Plug.Upload(path: path, filename: Path.basename(path), content_type: content_type)
+    %Plug.Upload{path: path, filename: Path.basename(path), content_type: content_type}
   end
 
   defp test_changesets(header, func, mod, block) do

--- a/test/support/changeset_case.ex
+++ b/test/support/changeset_case.ex
@@ -20,6 +20,10 @@ defmodule Cadet.ChangesetCase do
     test_changesets("Invalid", &refute/2, mod, block)
   end
 
+  def build_upload(path, content_type \\ "image\png") do
+    %Plug.Upload(path: path, filename: Path.basename(path), content_type: content_type)
+  end
+
   defp test_changesets(header, func, mod, block) do
     params =
       case block do


### PR DESCRIPTION
Currently arc tests are silently failing (if you notice nothing is uploaded to `/upload/test/*`) because `cast_attachment` is actually expecting a `%Plug.Upload{}` struct, so I added a helper and fixed existing tests.