### PR TITLE
Change Poison -> Jason for JSON parser and generator

### DIFF
--- a/lib/cadet/accounts/ivle.ex
+++ b/lib/cadet/accounts/ivle.ex
@@ -129,7 +129,7 @@ defmodule Cadet.Accounts.IVLE do
   """
   def api_call(method, queries) when method in ["Announcements"] do
     with {:ok, %{status_code: 200, body: body}} <- HTTPoison.get(api_url(method, queries)),
-         body = Poison.decode!(body),
+         body = Jason.decode!(body),
          %{"Comments" => "Valid login!"} <- body do
       {:ok, body["Results"]}
     else
@@ -165,7 +165,7 @@ defmodule Cadet.Accounts.IVLE do
   def api_call(method, queries) do
     case HTTPoison.get(api_url(method, queries)) do
       {:ok, %{body: body, status_code: 200}} when body != ~s("") ->
-        {:ok, Poison.decode!(body)}
+        {:ok, Jason.decode!(body)}
 
       {:ok, %{status_code: 500}} ->
         # IVLE responds with 500 if APIKey is invalid

--- a/lib/cadet_web/endpoint.ex
+++ b/lib/cadet_web/endpoint.ex
@@ -28,7 +28,7 @@ defmodule CadetWeb.Endpoint do
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Poison
+    json_decoder: Jason
   )
 
   plug(Plug.MethodOverride)

--- a/mix.exs
+++ b/mix.exs
@@ -53,6 +53,7 @@ defmodule Cadet.Mixfile do
       {:guardian, "~> 1.0"},
       {:guardian_db, "~> 1.0"},
       {:httpoison, "~> 1.0", override: true},
+      {:jason, "~> 1.1"},
       {:pbkdf2_elixir, "~> 0.12"},
       {:phoenix, "~> 1.3.0"},
       {:phoenix_ecto, "~> 3.2"},

--- a/mix.lock
+++ b/mix.lock
@@ -39,7 +39,7 @@
   "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm"},
-  "meck": {:hex, :meck, "0.8.10", "455aaef8403be46752272206613e7a15467c014d40994b22fb54cde4d1ff7075", [:rebar3], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.11", "2c39e15ec87d847da6cf69b4a1c4af3fd850ae2a272e719e0e8751a7fe54771f", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},

--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -76,7 +76,7 @@ defmodule Cadet.AssessmentsTest do
           type: :programming,
           question: %{},
           raw_question:
-            Poison.encode!(%{
+            Jason.encode!(%{
               content: "asd",
               solution_template: "template",
               solution: "soln",
@@ -99,7 +99,7 @@ defmodule Cadet.AssessmentsTest do
           type: :multiple_choice,
           question: %{},
           raw_question:
-            Poison.encode!(%{content: "asd", choices: [%{is_correct: true, content: "asd"}]})
+            Jason.encode!(%{content: "asd", choices: [%{is_correct: true, content: "asd"}]})
         },
         assessment.id
       )
@@ -118,7 +118,7 @@ defmodule Cadet.AssessmentsTest do
           type: :multiple_choice,
           question: %{},
           raw_question:
-            Poison.encode!(%{content: "asd", choices: [%{is_correct: true, content: "asd"}]})
+            Jason.encode!(%{content: "asd", choices: [%{is_correct: true, content: "asd"}]})
         },
         assessment.id
       )

--- a/test/cadet/assessments/question_test.exs
+++ b/test/cadet/assessments/question_test.exs
@@ -25,8 +25,8 @@ defmodule Cadet.Assessments.QuestionTest do
       title: "sample title",
       question: %{},
       type: :programming,
-      raw_library: Poison.encode!(%{week: 5, globals: [], externals: [], files: []}),
-      raw_question: Poison.encode!(%{question: "This is a sample json"}),
+      raw_library: Jason.encode!(%{week: 5, globals: [], externals: [], files: []}),
+      raw_question: Jason.encode!(%{question: "This is a sample json"}),
       assessment_id: 2
     }
   end


### PR DESCRIPTION
For performance reasons: quoting its README:
> The parser and generator are at least twice as fast as other Elixir/Erlang libraries (most notably `Poison`). The performance is comparable to `jiffy`, which is implemented in C as a NIF. Jason is usually only twice as slow.