### PR TITLE
Fix changeset helper to use casted embedded struct

### DIFF
--- a/lib/cadet/assessments/answer_types/mcq_answer.ex
+++ b/lib/cadet/assessments/answer_types/mcq_answer.ex
@@ -5,6 +5,7 @@ defmodule Cadet.Assessments.AnswerTypes.MCQAnswer do
   """
   use Cadet, :model
 
+  @primary_key false
   embedded_schema do
     field(:choice_id, :integer)
   end

--- a/lib/cadet/assessments/answer_types/programming_answer.ex
+++ b/lib/cadet/assessments/answer_types/programming_answer.ex
@@ -4,6 +4,7 @@ defmodule Cadet.Assessments.AnswerTypes.ProgrammingAnswer do
   """
   use Cadet, :model
 
+  @primary_key false
   embedded_schema do
     field(:code, :string)
   end

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -291,15 +291,18 @@ defmodule Cadet.Assessments do
   defp insert_or_update_answer(submission = %Submission{}, question = %Question{}, raw_answer) do
     answer_content = build_answer_content(raw_answer, question.type)
 
-    %Answer{}
-    |> Answer.changeset(%{
-      answer: answer_content,
-      question_id: question.id,
-      submission_id: submission.id,
-      type: question.type
-    })
-    |> Repo.insert(
-      on_conflict: [set: [answer: answer_content]],
+    answer_changeset =
+      %Answer{}
+      |> Answer.changeset(%{
+        answer: answer_content,
+        question_id: question.id,
+        submission_id: submission.id,
+        type: question.type
+      })
+
+    Repo.insert(
+      answer_changeset,
+      on_conflict: [set: [answer: get_change(answer_changeset, :answer)]],
       conflict_target: [:submission_id, :question_id]
     )
   end

--- a/lib/cadet/assessments/external_library.ex
+++ b/lib/cadet/assessments/external_library.ex
@@ -6,6 +6,7 @@ defmodule Cadet.Assessments.Library.ExternalLibrary do
 
   alias Cadet.Assessments.Library.ExternalLibraryName
 
+  @primary_key false
   embedded_schema do
     field(:name, ExternalLibraryName, default: :none)
     field(:symbols, {:array, :string}, default: [])

--- a/lib/cadet/assessments/library.ex
+++ b/lib/cadet/assessments/library.ex
@@ -6,6 +6,7 @@ defmodule Cadet.Assessments.Library do
 
   alias Cadet.Assessments.Library.ExternalLibrary
 
+  @primary_key false
   embedded_schema do
     field(:chapter, :integer, default: 1)
     field(:globals, :map, default: %{})

--- a/lib/cadet/assessments/question_types/mcq_question.ex
+++ b/lib/cadet/assessments/question_types/mcq_question.ex
@@ -7,6 +7,7 @@ defmodule Cadet.Assessments.QuestionTypes.MCQQuestion do
 
   alias Cadet.Assessments.QuestionTypes.MCQChoice
 
+  @primary_key false
   embedded_schema do
     field(:content, :string)
     embeds_many(:choices, MCQChoice)

--- a/lib/cadet/assessments/question_types/programming_question.ex
+++ b/lib/cadet/assessments/question_types/programming_question.ex
@@ -4,6 +4,7 @@ defmodule Cadet.Assessments.QuestionTypes.ProgrammingQuestion do
   """
   use Cadet, :model
 
+  @primary_key false
   embedded_schema do
     field(:content, :string)
     field(:solution_template, :string)

--- a/test/cadet/assessments/answer_test.exs
+++ b/test/cadet/assessments/answer_test.exs
@@ -66,6 +66,17 @@ defmodule Cadet.Assessments.AnswerTest do
       assert_changeset(params, :valid)
     end
 
+    test "converts valid mcq params with string value to integer", %{valid_mcq_params: params} do
+      string_params = Map.put(params, :answer, %{choice_id: "0"})
+
+      answer =
+        %Answer{}
+        |> Answer.changeset(string_params)
+        |> Repo.insert!()
+
+      assert is_integer(answer.answer.choice_id)
+    end
+
     test "invalid changeset mcq question wrong answer format", %{valid_mcq_params: params} do
       params_wrong_type = Map.put(params, :answer, %{choice_id: "hello world"})
       assert_changeset(params_wrong_type, :invalid)


### PR DESCRIPTION
Fixes #162 

For context, `answer: %{choice_id: "1"}` can be validly cast with a `field(:choice_id, :integer)` so it passes validation, but this will not be reflected in the original changeset.