### PR TITLE
Fail Cadet.Public.Updater silently in dev/test environments

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -12,7 +12,7 @@ config :cadet, environment: :test
 config :pbkdf2_elixir, :rounds, 1
 
 # Print only warnings and errors during test
-config :logger, level: :warn, compile_time_purge_level: :warn
+config :logger, level: :error, compile_time_purge_level: :error
 
 # Don't save secret keys in ExVCR cassettes
 config :exvcr,

--- a/lib/cadet/updater/public.ex
+++ b/lib/cadet/updater/public.ex
@@ -16,14 +16,13 @@ defmodule Cadet.Updater.Public do
   @api_key :cadet |> Application.fetch_env!(:updater) |> Keyword.get(:ivle_key)
   @api_url "https://ivle.nus.edu.sg"
   @api_url_login @api_url |> URI.merge("api/login/?apikey=#{@api_key}&url=_") |> URI.to_string()
+  @env Mix.env()
   @interval :cadet |> Application.fetch_env!(:updater) |> Keyword.get(:interval)
   @username :cadet |> Application.fetch_env!(:updater) |> Keyword.get(:guest_username)
   @password :cadet |> Application.fetch_env!(:updater) |> Keyword.get(:guest_password)
 
   @doc """
   Starts the GenServer.
-
-  WARNING: The GenServer crashes if the API key is invalid, or not provided.
   """
   def start_link do
     GenServer.start_link(__MODULE__, nil)
@@ -37,12 +36,26 @@ defmodule Cadet.Updater.Public do
 
   `start_link/0` -> `init/1` -> `schedule_work/0` -> `handle_info/2` ->
     `schedule_work/0` -> `handle_info/2` -> ...
+
+  Unless compiled with MIX_ENV of :prod, the GenServer fails silently (and only
+  once). We don't want IVLE accounts to be completely necessary for development.
   """
   def init(_) do
     Logger.info("Running Cadet.Updater.Public...")
-    api_params = get_api_params()
-    schedule_work()
-    {:ok, api_params}
+
+    try do
+      api_params = get_api_params()
+      schedule_work()
+      {:ok, api_params}
+    rescue
+      error in FunctionClauseError ->
+        if @env != :prod do
+          Logger.warn("Cadet.Updater.Public failed to initialise.")
+          {:ok, nil}
+        else
+          reraise error, System.stacktrace()
+        end
+    end
   end
 
   @impl true
@@ -53,14 +66,14 @@ defmodule Cadet.Updater.Public do
   """
   def handle_info(:work, api_params) do
     with {:ok, announcements} <- get_announcements(api_params.token, api_params.course_id) do
-      Logger.info("Updater fetched #{length(announcements)} announcements from IVLE")
+      Logger.info("Cadet.Updater.Public fetched #{length(announcements)} announcements from IVLE")
       # TODO: Act on announcements fetched
       schedule_work()
       {:noreply, api_params}
     else
       {:error, :bad_request} ->
         # the token has probably expired---get a new one
-        Logger.info("Updater failed fetching announcements. Refreshing token...")
+        Logger.info("Cadet.Updater.Public failed fetching announcements. Refreshing token...")
         api_params = get_api_params()
         handle_info(:work, api_params)
     end
@@ -171,6 +184,7 @@ defmodule Cadet.Updater.Public do
   end
 
   # Extracts the location of a 302 redirect from a %HTTPoison.Response
+  # Returns nil if no location in header (POST login form failed)
   defp get_redirect_path(response) do
     response.headers
     |> Enum.into(%{})

--- a/test/cadet/updater/public_test.exs
+++ b/test/cadet/updater/public_test.exs
@@ -87,12 +87,20 @@ defmodule Cadet.Updater.PublicTest do
     end
   end
 
-  test "GenServer init/1 callback" do
-    use_cassette "updater/init#1", custom: true do
-      assert {:ok, %{token: token, course_id: course_id}} = Public.init(nil)
-      assert String.length(token) == 480
-      assert String.length(course_id) == 36
-      refute course_id == "00000000-0000-0000-0000-000000000000"
+  describe "GenServer init/1 callback" do
+    test "get_api_params/0 is successful" do
+      use_cassette "updater/init#1", custom: true do
+        assert {:ok, %{token: token, course_id: course_id}} = Public.init(nil)
+        assert String.length(token) == 480
+        assert String.length(course_id) == 36
+        refute course_id == "00000000-0000-0000-0000-000000000000"
+      end
+    end
+
+    test "get_api_params/0 is unsuccessful in non-prod environment" do
+      use_cassette "updater/init#2", custom: true do
+        assert {:ok, nil} = Public.init(nil)
+      end
     end
   end
 

--- a/test/fixtures/custom_cassettes/updater/init#2.json
+++ b/test/fixtures/custom_cassettes/updater/init#2.json
@@ -1,0 +1,58 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "~r/https://ivle.nus.edu.sg/api/login/\?apikey=.*/"
+    },
+    "response": {
+      "binary": false,
+      "body": "\r\n\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n\r\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\r\n<head><title>\r\n\tLogin | IVLE\r\n</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, maximum-scale=1\" /></head>\r\n<body>\r\n<!-- Header -->\r\n    <table border=\"0\" style=\"background: #4F4E52;color: White; font-weight:bold\" width=\"100%\" cellpadding=\"8\" cellspacing=\"8\">\r\n        <tr><td width=\"*\">Access to IVLE requested</td>\r\n        <!-- <td width=\"20px\"><a onclick=\"parent.ivle_close();\" title=\"Close\">[X]</a></td> -->\r\n        </tr>\r\n    </table>\r\n    <form name=\"frm\" method=\"post\" action=\"./?apikey=&amp;url=_\" id=\"frm\">\r\n<input type=\"hidden\" name=\"__VIEWSTATE\" id=\"__VIEWSTATE\" value=\"/wEPDwULLTEzODMyMDQxNjEPFgIeE1ZhbGlkYXRlUmVxdWVzdE1vZGUCARYCAgEPZBYEAgEPD2QWAh4Gb25ibHVyBQ91c2VySWRUb1VwcGVyKClkAgkPD2QWBB4Lb25tb3VzZW92ZXIFNWRvY3VtZW50LmdldEVsZW1lbnRCeUlkKCdsb2dpbmltZzEnKS5zcmM9b2ZmaW1nLnNyYzE7Hgpvbm1vdXNlb3V0BTRkb2N1bWVudC5nZXRFbGVtZW50QnlJZCgnbG9naW5pbWcxJykuc3JjPW9uaW1nLnNyYzE7ZBgBBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAQUJbG9naW5pbWcxYTg4Q/LO3lNCB13iJpTeINmF1JQmGv61ni1TVgDIOII=\" />\r\n\r\n<input type=\"hidden\" name=\"__VIEWSTATEGENERATOR\" id=\"__VIEWSTATEGENERATOR\" value=\"B0AF59B8\" />\r\n    <table border=\"0\">\r\n    <tr valign=\"top\"><td>UserID</td><td>:</td><td> <input name=\"userid\" type=\"text\" maxlength=\"30\" id=\"userid\" onblur=\"userIdToUpper()\" />\r\n                                                  </td></tr>\r\n    <tr valign=\"top\"><td>Password</td><td>:</td><td><input name=\"password\" type=\"password\" maxlength=\"100\" id=\"password\" />\r\n                                                  </td></tr>\r\n                                                  <tr valign=\"top\"><td colspan=\"3\">\r\n <input type=\"image\" name=\"loginimg1\" id=\"loginimg1\" onmouseover=\"document.getElementById(&#39;loginimg1&#39;).src=offimg.src1;\" onmouseout=\"document.getElementById(&#39;loginimg1&#39;).src=onimg.src1;\" src=\"/images/login.gif\" onclick=\"javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;loginimg1&quot;, &quot;&quot;, true, &quot;login&quot;, &quot;&quot;, false, false))\" border=\"0\" />\r\n                                                  <br />\r\n                                                  \r\n                                                  \r\n                                                  </td></tr>\r\n    </table>\r\n    </form>\r\n    <script language=\"javascript\">\r\n        var onimg = new Image();\r\n        var offimg = new Image();\r\n        onimg.src = \"/images/enter_new.gif\"; offimg.src = \"/images/enter_h_new.gif\";\r\n        onimg.src1 = \"/images/login.gif\"; offimg.src1 = \"/images/login_h.gif\";\r\n\r\n        function userIdToUpper() {\r\n            var txt = document.getElementById(\"userid\");\r\n            txt.value = txt.value.toUpperCase();\r\n        }    \r\n    </script>\r\n</body>\r\n</html>\r\n",
+      "headers": {
+        "Cache-Control": "private",
+        "Content-Type": "text/html; charset=utf-8",
+        "Server": "Microsoft-IIS/8.5",
+        "Request-Context": "appId=cid-v1:9bebd252-0be2-48b7-a1db-8e2b70524944",
+        "Set-Cookie": "ASP.NET_SessionId=j3454drj4cgysz2g2grd0ibo; path=/; HttpOnly",
+        "X-AspNet-Version": "4.0.30319",
+        "X-Powered-By": "ASP.NET",
+        "Date": "Fri, 27 Jul 2018 07:18:04 GMT",
+        "Content-Length": "2942"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "~r/.*/",
+      "headers": [],
+      "method": "post",
+      "options": {
+        "cookie": "ASP.NET_SessionId=j3454drj4cgysz2g2grd0ibo; path=/; HttpOnly",
+        "follow_redirect": "false"
+      },
+      "request_body": "",
+      "url": "~r/https://ivle.nus.edu.sg/api/login/\?apikey=.*/"
+    },
+    "response": {
+      "binary": false,
+      "body": "\r\n\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n\r\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\r\n<head><title>\r\n\tLogin | IVLE\r\n</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, maximum-scale=1\" /></head>\r\n<body>\r\n<!-- Header -->\r\n    <table border=\"0\" style=\"background: #4F4E52;color: White; font-weight:bold\" width=\"100%\" cellpadding=\"8\" cellspacing=\"8\">\r\n        <tr><td width=\"*\">Access to IVLE requested</td>\r\n        <!-- <td width=\"20px\"><a onclick=\"parent.ivle_close();\" title=\"Close\">[X]</a></td> -->\r\n        </tr>\r\n    </table>\r\n    <form name=\"frm\" method=\"post\" action=\"./?apikey=&amp;url=_\" id=\"frm\">\r\n<input type=\"hidden\" name=\"__VIEWSTATE\" id=\"__VIEWSTATE\" value=\"/wEPDwULLTEzODMyMDQxNjEPFgIeE1ZhbGlkYXRlUmVxdWVzdE1vZGUCARYCAgEPZBYEAgEPD2QWAh4Gb25ibHVyBQ91c2VySWRUb1VwcGVyKClkAgkPD2QWBB4Lb25tb3VzZW92ZXIFNWRvY3VtZW50LmdldEVsZW1lbnRCeUlkKCdsb2dpbmltZzEnKS5zcmM9b2ZmaW1nLnNyYzE7Hgpvbm1vdXNlb3V0BTRkb2N1bWVudC5nZXRFbGVtZW50QnlJZCgnbG9naW5pbWcxJykuc3JjPW9uaW1nLnNyYzE7ZBgBBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAQUJbG9naW5pbWcxYTg4Q/LO3lNCB13iJpTeINmF1JQmGv61ni1TVgDIOII=\" />\r\n\r\n<input type=\"hidden\" name=\"__VIEWSTATEGENERATOR\" id=\"__VIEWSTATEGENERATOR\" value=\"B0AF59B8\" />\r\n    <table border=\"0\">\r\n    <tr valign=\"top\"><td>UserID</td><td>:</td><td> <input name=\"userid\" type=\"text\" maxlength=\"30\" id=\"userid\" onblur=\"userIdToUpper()\" />\r\n                                                  </td></tr>\r\n    <tr valign=\"top\"><td>Password</td><td>:</td><td><input name=\"password\" type=\"password\" maxlength=\"100\" id=\"password\" />\r\n                                                  </td></tr>\r\n                                                  <tr valign=\"top\"><td colspan=\"3\">\r\n <input type=\"image\" name=\"loginimg1\" id=\"loginimg1\" onmouseover=\"document.getElementById(&#39;loginimg1&#39;).src=offimg.src1;\" onmouseout=\"document.getElementById(&#39;loginimg1&#39;).src=onimg.src1;\" src=\"/images/login.gif\" onclick=\"javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;loginimg1&quot;, &quot;&quot;, true, &quot;login&quot;, &quot;&quot;, false, false))\" border=\"0\" />\r\n                                                  <br />\r\n                                                  \r\n                                                  \r\n                                                  </td></tr>\r\n    </table>\r\n    </form>\r\n    <script language=\"javascript\">\r\n        var onimg = new Image();\r\n        var offimg = new Image();\r\n        onimg.src = \"/images/enter_new.gif\"; offimg.src = \"/images/enter_h_new.gif\";\r\n        onimg.src1 = \"/images/login.gif\"; offimg.src1 = \"/images/login_h.gif\";\r\n\r\n        function userIdToUpper() {\r\n            var txt = document.getElementById(\"userid\");\r\n            txt.value = txt.value.toUpperCase();\r\n        }    \r\n    </script>\r\n</body>\r\n</html>\r\n",
+      "headers": {
+        "Cache-Control": "private",
+        "Content-Type": "text/html; charset=utf-8",
+        "Server": "Microsoft-IIS/8.5",
+        "Request-Context": "appId=cid-v1:9bebd252-0be2-48b7-a1db-8e2b70524944",
+        "X-AspNet-Version": "4.0.30319",
+        "X-Powered-By": "ASP.NET",
+        "Date": "Fri, 27 Jul 2018 07:18:04 GMT",
+        "Content-Length": "2942"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]


### PR DESCRIPTION
Previously, an invalid GUEST_USERNAME or GUEST_PASSWORD would cause the application to crash if started with the `--updater` flag.

This should not be the case, since the `--updater` flag now encompasses more than just the news/material updater (namely, we have the assessment XML toolchain here). Someone trying to work on and test the application for the XML toolchain should not have to provide a GUEST_USERNAME or GUEST_PASSWORD in order to test their XML toolchain in the updater.

We're not 1.7 yet so no `__STACKTRACE__`.