### PR TITLE
Add fallback user story fetching logic

### DIFF
--- a/lib/cadet_web/controllers/user_controller.ex
+++ b/lib/cadet_web/controllers/user_controller.ex
@@ -44,9 +44,24 @@ defmodule CadetWeb.UserController do
               required: true
             )
 
-            story(:string, "Story to displayed to current user. May be null")
+            story(Schema.ref(:UserStory), "Story to displayed to current user. ")
 
             grade(:integer, "Amount of grade. Only provided for 'Student'")
+          end
+        end,
+      UserStory:
+        swagger_schema do
+          properties do
+            story(
+              :string,
+              "Name of story to be displayed to current user. May only be null before start of semester" <>
+                " when no assessments are open"
+            )
+
+            allAttempted(
+              :boolean,
+              "Whether all currently available stories have been attempted (allow open world)"
+            )
           end
         end
     }

--- a/lib/cadet_web/views/user_view.ex
+++ b/lib/cadet_web/views/user_view.ex
@@ -2,6 +2,15 @@ defmodule CadetWeb.UserView do
   use CadetWeb, :view
 
   def render("index.json", %{user: user, grade: grade, story: story}) do
-    %{name: user.name, role: user.role, grade: grade, story: story}
+    %{
+      name: user.name,
+      role: user.role,
+      grade: grade,
+      story:
+        transform_map_for_view(story, %{
+          story: :story,
+          allAttempted: :all_attempted
+        })
+    }
   end
 end


### PR DESCRIPTION
Fixes #179 

When logic in #173 causes no story to be found, `story["allAttemped"]` will be `true` and the following logic will be used to find a story:
  - Filter by:
    - assessment is published
    - assessment story is not nil
    - assessment `open_at` is before now and `close_at` is after now
    - **NO** submission status filtering
  - Sort by:
    - Assessment `close_at`, descending
    - Assessment type (path>mission>sidequest>contest) for assessments that close at the same time

@ningyuansg Note that the `story` field may be `{story: null, allAttempted: true}` in the event that both methods fail to find a qualifying story. At the moment, the only time I see this happening is at the start of semester before any assessment is open.