### PR TITLE
Add timeout to lambda, fix name conflicts

### DIFF
--- a/terraform/cadet/inputs.tf
+++ b/terraform/cadet/inputs.tf
@@ -34,6 +34,14 @@ variable "lambda_filename" {
   description = "Location of the lambda deployment zip"
 }
 
+variable "lambda_timeout" {
+  description = "Timeout duration of the lambda service (seconds)"
+}
+
+variable "grader_timeout" {
+  description = "TIMEOUT_DURATION of the grader (milliseconds)"
+}
+
 variable "ssh_public_key" {
   description = "Public SSH Key Used by the Instance"
 }

--- a/terraform/cadet/lambda.tf
+++ b/terraform/cadet/lambda.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "grader" {
-  name = "grader"
+  name = "${var.env}-cadet-grader"
 
   assume_role_policy = <<EOF
 {

--- a/terraform/cadet/lambda.tf
+++ b/terraform/cadet/lambda.tf
@@ -24,5 +24,12 @@ resource "aws_lambda_function" "grader" {
   handler          = "index.runAll"
   role             = "${aws_iam_role.grader.arn}"
   runtime          = "nodejs8.10"
+  timeout          = "${var.lambda_timeout}"
   source_code_hash = "${base64sha256(file("${var.lambda_filename}"))}"
+
+  environment {
+    variables = {
+      TIMEOUT = "${var.grader_timeout}"
+    }
+  }
 }

--- a/terraform/cadet/rds.tf
+++ b/terraform/cadet/rds.tf
@@ -1,5 +1,5 @@
-resource "aws_db_subnet_group" "main" {
-  name = "main"
+resource "aws_db_subnet_group" "db" {
+  name = "${var.env}-cadet-db"
   subnet_ids = ["${aws_subnet.private_a.id}", "${aws_subnet.private_b.id}"]
 
   tags {
@@ -11,7 +11,7 @@ resource "aws_db_subnet_group" "main" {
 resource "aws_db_instance" "db" {
   name                   = "${title(var.env)}CadetDB"
   instance_class         = "${var.rds_instance_class}"
-  db_subnet_group_name   = "${aws_db_subnet_group.main.name}"
+  db_subnet_group_name   = "${aws_db_subnet_group.db.name}"
   vpc_security_group_ids = ["${aws_security_group.db.id}"]
   allocated_storage      = "${var.rds_allocated_storage}"
   storage_type           = "gp2"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,5 +26,7 @@ module "staging" {
   rds_allocated_storage = 10
   rds_password          = "postgres"
   lambda_filename       = "~/grader/grader.zip"
+  lambda_timeout        = 30
+  grader_timeout        = "20000"
   ssh_public_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5LX23pkdYNFlXdAr/24hND0YUNynL1LCd4hQQxGGx0LBcrKOsHekpXTh091eFk7DvXQpq828VdnZdd6lTDrdmR9j9Uf5xRpRA81TNHC3HhDxgdfJleoMFu8eF44WPtt6ItxqC2ajP2Lw3UJgEctTpUyqlOrETRxhMpMNzxhIgLw9ygesiuGdtN6LaItW3R2Ec8pBxboPrMxBWze++CAG5mpRinI9BuONxBG1DAOQFitcLgGu+p9zpwJcNYRJwrZDlG98g+BsU2b4eEamXbQAxLdFLMHZPDCmV2a01pSfPIaQXoAKZqj/nGLPsTL1FIjZIxXNHtV7Tvvct4HtvzUaNDg1miLV6zlvFPTWMcE7dV+Mbj2aS1sl2eTcLZ5XTJr4so43nf4lH1ujxBODNCCm/68ck9wlf2GUkqyp+dPHr/ObMRcX6JSYs1c8NseSJlDmc87MCclGyxkBA+6on/3IUGsogz4gHupVJdVoR8ffWT2+jk06XLQmVIM1Th2JjV152Htn39RRmId6WuoynMCinaTaB/b5m4cEZNdttLlRmqbRCsOAr/W+BuWH9jtNi/c1qKZBJLyZE408JB9CCe+tFJgQ1hNDL+RAUKlLk6F7Xivft1nYaV58FA3U27mtMPp+RZItALTNAmA/pKfS7W4ACOhDHfpEfmUA4IzaJfruKYQ== ningyuan.sg@gmail.com"
 }


### PR DESCRIPTION
1. Lambda timeouts (as well as the grader timeout) has been added as part of the terraform files.
    - Lambda timeout is the duration before AWS timeouts the node process; a lambda timeout results in a 504 Gateway Timeout, and all information is lost.
    - Grader timeout is the duration that the grader program gives each student + grader program combination to run (they run in parallel); a grader timeout results in a error only for that one student + grader program, and the other successful programs are unaffected (they still return their grades). See https://github.com/source-academy/grader/pull/15.
2. Fix some problems with name conflicts between staging and production resources.