### PR TITLE
Fix distillery compilation errors

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,11 +35,11 @@ config :logger, :console,
 
 # Configure ExAWS
 config :ex_aws,
-  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, {:awscli, "default", 30}, :instance_role],
+  access_key_id: [:instance_role, {:system, "AWS_ACCESS_KEY_ID"}, {:awscli, "default", 30}],
   secret_access_key: [
+    :instance_role,
     {:system, "AWS_SECRET_ACCESS_KEY"},
-    {:awscli, "default", 30},
-    :instance_role
+    {:awscli, "default", 30}
   ],
   region: "ap-southeast-1"
 

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -46,8 +46,6 @@ end
 
 release :cadet do
   set version: current_version(:cadet)
-  set applications: [
-    :runtime_tools
-  ]
+  set applications: [:runtime_tools, :ex_utils, :memento]
 end
 


### PR DESCRIPTION
With `PORT=4000 MIX_ENV=prod iex -S mix`, I get the error message during compilation, _if_ `:instance_role` is not the first element of `:ex_aws` config lists:

```
10:18:16.831 [error] GenServer ExAws.Config.AuthCache terminating
** (RuntimeError) ConfigParser required to use
    (ex_aws) lib/ex_aws/credentials_ini.ex:68: ExAws.CredentialsIni.security_credentials/1
    (ex_aws) lib/ex_aws/config/auth_cache.ex:51: ExAws.Config.AuthCache.refresh_awscli_config/3
    (ex_aws) lib/ex_aws/config/auth_cache.ex:37: ExAws.Config.AuthCache.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message (from Cadet.Repo): {:refresh_awscli_config, "default", 30000}
10:18:16.833 [info] Application cadet exited: Cadet.Application.start(:normal, []) returned an error: shutdown: failed to start child: Cadet.Repo
    ** (EXIT) exited in: GenServer.call(ExAws.Config.AuthCache, {:refresh_awscli_config, "default", 30000}, 30000)
        ** (EXIT) an exception was raised: 
            ** (RuntimeError) ConfigParser required to use
                (ex_aws) lib/ex_aws/credentials_ini.ex:68: ExAws.CredentialsIni.security_credentials/1
                (ex_aws) lib/ex_aws/config/auth_cache.ex:51: ExAws.Config.AuthCache.refresh_awscli_config/3
                (ex_aws) lib/ex_aws/config/auth_cache.ex:37: ExAws.Config.AuthCache.handle_call/3
                (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
                (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
                (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
** (Mix) Could not start application cadet: Cadet.Application.start(:normal, []) returned an error: shutdown: failed to start child: Cadet.Repo
    ** (EXIT) exited in: GenServer.call(ExAws.Config.AuthCache, {:refresh_awscli_config, "default", 30000}, 30000)
        ** (EXIT) an exception was raised:
            ** (RuntimeError) ConfigParser required to use
                (ex_aws) lib/ex_aws/credentials_ini.ex:68: ExAws.CredentialsIni.security_credentials/1
                (ex_aws) lib/ex_aws/config/auth_cache.ex:51: ExAws.Config.AuthCache.refresh_awscli_config/3
                (ex_aws) lib/ex_aws/config/auth_cache.ex:37: ExAws.Config.AuthCache.handle_call/3
                (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
                (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
                (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

Without `:ex_utils` and `:memento` in `:applications` in `rel/config.exs`, I get the following warning during compilation with the same `MIX_ENV=prod mix release --env=prod`:

```
!PROD-BUILD! bitnami@ip-172-31-11-189:~/cadet$ MIX_ENV=prod mix release --env=prod
==> Assembling release..
==> Building release cadet:0.0.1 using environment prod
==> One or more direct or transitive dependencies are missing from
    :applications or :included_applications, they will not be included
    in the release:

    :ex_utils
    :memento

    This can cause your application to fail at runtime. If you are sure
    that this is not an issue, you may ignore this warning.

==> Including ERTS 10.0 from /usr/lib/erlang/erts-10.0
==> Packaging release..
==> Release successfully built!
    You can run it in one of the following ways:
      Interactive: _build/prod/rel/cadet/bin/cadet console
      Foreground: _build/prod/rel/cadet/bin/cadet foreground
      Daemon: _build/prod/rel/cadet/bin/cadet start
```

The resulting cadet binary then fails with a runtime error.

```
10:01:55.495 [info] [Que] Booting Que
10:01:55.497 [info] [Que] Booting Server Supervisor for Workers
10:01:55.499 [info] Application que exited: Que.start(:normal, []) returned an error: shutdown: failed to start child: Que.ServerSupervisor
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Memento.Query.build/2 is undefined (module Memento.Query is not available)
            Memento.Query.build(%{arguments: :"$2", created_at: :"$7", id: :"$1", pid: :"$6", ref: :"$5", status: :"$4", updated_at: :"$8", worker: :"$3"}, {:or, {:==, :status, :queued}, {:==, :status, :started}})
            (que) lib/que/persistence/mnesia.ex:280: anonymous fn/1 in Que.Persistence.Mnesia.DB.Jobs.run_query/1
            (mnesia) mnesia_tm.erl:836: :mnesia_tm.apply_fun/3
            (mnesia) mnesia_tm.erl:812: :mnesia_tm.execute_transaction/5
            (que) lib/que/persistence/mnesia.ex:278: Que.Persistence.Mnesia.DB.Jobs.run_query/1
            (que) lib/que/server_supervisor.ex:72: Que.ServerSupervisor.resume_queued_jobs/0
            (que) lib/que/server_supervisor.ex:24: Que.ServerSupervisor.start_link/0
            (stdlib) supervisor.erl:379: :supervisor.do_start_child_i/3
{"Kernel pid terminated",application_controller,"{application_start_failure,que,{{shutdown,{failed_to_start_child,'Elixir.Que.ServerSupervisor',{'EXIT',{#{'__exception__' => true,'__struct__' => 'Elixir.UndefinedFunctionError',arity => 2,exports => nil,function => build,module => 'Elixir.Memento.Query',reason => nil},[{'Elixir.Memento.Query',build,[#{arguments => '$2',created_at => '$7',id => '$1',pid => '$6',ref => '$5',status => '$4',updated_at => '$8',worker => '$3'},{'or',{'==',status,queued},{'==',status,started}}],[]},{'Elixir.Que.Persistence.Mnesia.DB.Jobs','-run_query/1-fun-1-',1,[{file,\"lib/que/persistence/mnesia.ex\"},{line,280}]},{mnesia_tm,apply_fun,3,[{file,\"mnesia_tm.erl\"},{line,836}]},{mnesia_tm,execute_transaction,5,[{file,\"mnesia_tm.erl\"},{line,812}]},{'Elixir.Que.Persistence.Mnesia.DB.Jobs',run_query,1,[{file,\"lib/que/persistence/mnesia.ex\"},{line,278}]},{'Elixir.Que.ServerSupervisor',resume_queued_jobs,0,[{file,\"lib/que/server_supervisor.ex\"},{line,72}]},{'Elixir.Que.ServerSupervisor',start_link,0,[{file,\"lib/que/server_supervisor.ex\"},{line,24}]},{supervisor,do_start_child_i,3,[{file,\"supervisor.erl\"},{line,379}]}]}}}},{'Elixir.Que',start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,que,{{shutdown,{failed_to_start_child,'Elixir.Que.ServerSupervisor',{'EXIT',{#{'__exception__' => true,'__struct__' => 'Elixi

Crash dump is being written to: erl_crash.dump...done
```