### PR TITLE
Implement XP

### DIFF
--- a/lib/cadet/assessments/answer.ex
+++ b/lib/cadet/assessments/answer.ex
@@ -13,6 +13,7 @@ defmodule Cadet.Assessments.Answer do
   schema "answers" do
     field(:grade, :integer, default: 0)
     field(:xp, :integer, default: 0)
+    field(:xp_adjustment, :integer, default: 0)
     field(:autograding_status, AutogradingStatus, default: :none)
     field(:autograding_errors, {:array, :map}, default: [])
     field(:answer, :map)

--- a/lib/cadet/assessments/answer.ex
+++ b/lib/cadet/assessments/answer.ex
@@ -13,7 +13,6 @@ defmodule Cadet.Assessments.Answer do
   schema "answers" do
     field(:grade, :integer, default: 0)
     field(:xp, :integer, default: 0)
-    field(:xp_bonus, :integer, default: 0)
     field(:xp_adjustment, :integer, default: 0)
     field(:autograding_status, AutogradingStatus, default: :none)
     field(:autograding_errors, {:array, :map}, default: [])
@@ -27,7 +26,7 @@ defmodule Cadet.Assessments.Answer do
   end
 
   @required_fields ~w(answer submission_id question_id type)a
-  @optional_fields ~w(xp xp_adjustment xp_bonus grade comment adjustment)a
+  @optional_fields ~w(xp xp_adjustment grade comment adjustment)a
 
   def changeset(answer, params) do
     answer
@@ -37,7 +36,6 @@ defmodule Cadet.Assessments.Answer do
     |> validate_required(@required_fields)
     |> validate_number(:grade, greater_than_or_equal_to: 0)
     |> validate_number(:xp, greater_than_or_equal_to: 0)
-    |> validate_number(:xp_bonus, greater_than_or_equal_to: 0)
     |> foreign_key_constraint(:submission_id)
     |> foreign_key_constraint(:question_id)
     |> validate_answer_content()

--- a/lib/cadet/assessments/answer.ex
+++ b/lib/cadet/assessments/answer.ex
@@ -13,6 +13,7 @@ defmodule Cadet.Assessments.Answer do
   schema "answers" do
     field(:grade, :integer, default: 0)
     field(:xp, :integer, default: 0)
+    field(:xp_bonus, :integer, default: 0)
     field(:xp_adjustment, :integer, default: 0)
     field(:autograding_status, AutogradingStatus, default: :none)
     field(:autograding_errors, {:array, :map}, default: [])
@@ -26,7 +27,7 @@ defmodule Cadet.Assessments.Answer do
   end
 
   @required_fields ~w(answer submission_id question_id type)a
-  @optional_fields ~w(grade comment adjustment)a
+  @optional_fields ~w(xp xp_adjustment xp_bonus grade comment adjustment)a
 
   def changeset(answer, params) do
     answer
@@ -34,7 +35,9 @@ defmodule Cadet.Assessments.Answer do
     |> add_belongs_to_id_from_model([:submission, :question], params)
     |> add_question_type_from_model(params)
     |> validate_required(@required_fields)
-    |> validate_number(:grade, greater_than_or_equal_to: 0.0)
+    |> validate_number(:grade, greater_than_or_equal_to: 0)
+    |> validate_number(:xp, greater_than_or_equal_to: 0)
+    |> validate_number(:xp_bonus, greater_than_or_equal_to: 0)
     |> foreign_key_constraint(:submission_id)
     |> foreign_key_constraint(:question_id)
     |> validate_answer_content()
@@ -43,13 +46,16 @@ defmodule Cadet.Assessments.Answer do
   @spec grading_changeset(%__MODULE__{} | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def grading_changeset(answer, params) do
     answer
-    |> cast(params, ~w(adjustment comment)a)
+    |> cast(params, ~w(xp_adjustment adjustment comment)a)
     |> validate_grade_adjustment_total()
   end
 
   @spec autograding_changeset(%__MODULE__{} | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def autograding_changeset(answer, params) do
-    cast(answer, params, ~w(grade adjustment xp autograding_status autograding_errors)a)
+    answer
+    |> cast(params, ~w(grade adjustment xp autograding_status autograding_errors)a)
+    |> validate_number(:grade, greater_than_or_equal_to: 0)
+    |> validate_number(:xp, greater_than_or_equal_to: 0)
   end
 
   @spec validate_grade_adjustment_total(Ecto.Changeset.t()) :: Ecto.Changeset.t()

--- a/lib/cadet/assessments/answer.ex
+++ b/lib/cadet/assessments/answer.ex
@@ -48,7 +48,7 @@ defmodule Cadet.Assessments.Answer do
 
   @spec autograding_changeset(%__MODULE__{} | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def autograding_changeset(answer, params) do
-    cast(answer, params, ~w(grade adjustment autograding_status autograding_errors)a)
+    cast(answer, params, ~w(grade adjustment xp autograding_status autograding_errors)a)
   end
 
   @spec validate_grade_adjustment_total(Ecto.Changeset.t()) :: Ecto.Changeset.t()

--- a/lib/cadet/assessments/answer.ex
+++ b/lib/cadet/assessments/answer.ex
@@ -12,6 +12,7 @@ defmodule Cadet.Assessments.Answer do
 
   schema "answers" do
     field(:grade, :integer, default: 0)
+    field(:xp, :integer, default: 0)
     field(:autograding_status, AutogradingStatus, default: :none)
     field(:autograding_errors, {:array, :map}, default: [])
     field(:answer, :map)

--- a/lib/cadet/assessments/assessment.ex
+++ b/lib/cadet/assessments/assessment.ex
@@ -11,6 +11,8 @@ defmodule Cadet.Assessments.Assessment do
   schema "assessments" do
     field(:max_grade, :integer, virtual: true)
     field(:max_xp, :integer, virtual: true)
+    field(:xp, :integer, virtual: true)
+    field(:grade, :integer, virtual: true)
     field(:user_status, SubmissionStatus, virtual: true)
     field(:title, :string)
     field(:is_published, :boolean, default: false)

--- a/lib/cadet/assessments/assessment.ex
+++ b/lib/cadet/assessments/assessment.ex
@@ -10,9 +10,9 @@ defmodule Cadet.Assessments.Assessment do
 
   schema "assessments" do
     field(:max_grade, :integer, virtual: true)
+    field(:grade, :integer, virtual: true)
     field(:max_xp, :integer, virtual: true)
     field(:xp, :integer, virtual: true)
-    field(:grade, :integer, virtual: true)
     field(:user_status, SubmissionStatus, virtual: true)
     field(:title, :string)
     field(:is_published, :boolean, default: false)

--- a/lib/cadet/assessments/assessment.ex
+++ b/lib/cadet/assessments/assessment.ex
@@ -10,6 +10,7 @@ defmodule Cadet.Assessments.Assessment do
 
   schema "assessments" do
     field(:max_grade, :integer, virtual: true)
+    field(:max_xp, :integer, virtual: true)
     field(:user_status, SubmissionStatus, virtual: true)
     field(:title, :string)
     field(:is_published, :boolean, default: false)

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -427,18 +427,25 @@ defmodule Cadet.Assessments do
 
       submissions =
         Submission
-        |> join(:inner, [s], x in subquery(Query.submissions_grade()), s.id == x.submission_id)
+        |> join(
+          :inner,
+          [s],
+          x in subquery(Query.submissions_xp_and_grade()),
+          s.id == x.submission_id
+        )
         |> join(:inner, [s], st in subquery(students), s.student_id == st.id)
         |> join(
           :inner,
           [s],
-          a in subquery(Query.all_assessments_with_max_grade()),
+          a in subquery(Query.all_assessments_with_max_xp_and_grade()),
           s.assessment_id == a.id
         )
         |> select([s, x, st, a], %Submission{
           s
           | grade: x.grade,
             adjustment: x.adjustment,
+            xp: x.xp,
+            xp_adjustment: x.xp_adjustment,
             student: st,
             assessment: a
         })

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -161,7 +161,7 @@ defmodule Cadet.Assessments do
   """
   def all_published_assessments(user = %User{}) do
     assessments =
-      Query.all_assessments_with_max_grade()
+      Query.all_assessments_with_max_xp_and_grade()
       |> subquery()
       |> join(:left, [a], s in Submission, a.id == s.assessment_id and s.student_id == ^user.id)
       |> select([a, s], %{a | user_status: s.status})

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -12,7 +12,7 @@ defmodule Cadet.Assessments do
   alias Cadet.Autograder.GradingJob
   alias Ecto.Multi
 
-  @xp_early_submission_bonus 100
+  @xp_early_submission_max_bonus 100
   @xp_bonus_assessment_type ~w(mission sidequest)a
   @submit_answer_roles ~w(student)a
   @grading_roles ~w(staff)a
@@ -381,11 +381,11 @@ defmodule Cadet.Assessments do
           0
 
         Timex.before?(Timex.now(), Timex.shift(assessment.open_at, hours: 48)) ->
-          @xp_early_submission_bonus
+          @xp_early_submission_max_bonus
 
         true ->
           deduction = Timex.diff(Timex.now(), assessment.open_at, :hours) - 48
-          Enum.max([0, @xp_early_submission_bonus - deduction])
+          Enum.max([0, @xp_early_submission_max_bonus - deduction])
       end
 
     submission

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -13,6 +13,7 @@ defmodule Cadet.Assessments do
   alias Ecto.Multi
 
   @xp_early_submission_bonus 100
+  @xp_bonus_assessment_type ~w(mission sidequest)a
   @submit_answer_roles ~w(student)a
   @grading_roles ~w(staff)a
   @open_all_assessment_roles ~w(staff admin)a
@@ -352,11 +353,16 @@ defmodule Cadet.Assessments do
       end
 
     xp_bonus =
-      if Timex.before?(Timex.now(), Timex.shift(assessment.open_at, hours: 48)) do
-        @xp_early_submission_bonus
-      else
-        deduction = Timex.diff(Timex.now(), assessment.open_at, :hours) - 48
-        Enum.max([0, @xp_early_submission_bonus - deduction])
+      cond do
+        assessment.type not in @xp_bonus_assessment_type ->
+          0
+
+        Timex.before?(Timex.now(), Timex.shift(assessment.open_at, hours: 48)) ->
+          @xp_early_submission_bonus
+
+        true ->
+          deduction = Timex.diff(Timex.now(), assessment.open_at, :hours) - 48
+          Enum.max([0, @xp_early_submission_bonus - deduction])
       end
 
     submission

--- a/lib/cadet/assessments/query.ex
+++ b/lib/cadet/assessments/query.ex
@@ -8,6 +8,17 @@ defmodule Cadet.Assessments.Query do
 
   @doc """
   Returns a query with the following bindings:
+  [submissions_with_xp, answers]
+  """
+  @spec all_submissions_with_xp :: Ecto.Query.t()
+  def all_submissions_with_xp do
+    Submission
+    |> join(:inner, [s], q in subquery(submissions_xp()), s.id == q.submission_id)
+    |> select([s, q], %Submission{s | xp: q.xp, xp_adjustment: q.xp_adjustment})
+  end
+
+  @doc """
+  Returns a query with the following bindings:
   [submissions_with_grade, answers]
   """
   @spec all_submissions_with_grade :: Ecto.Query.t()
@@ -36,6 +47,17 @@ defmodule Cadet.Assessments.Query do
       submission_id: a.submission_id,
       grade: sum(a.grade),
       adjustment: sum(a.adjustment)
+    })
+  end
+
+  @spec submissions_xp :: Ecto.Query.t()
+  def submissions_xp do
+    Answer
+    |> group_by(:submission_id)
+    |> select([a], %{
+      submission_id: a.submission_id,
+      xp: sum(a.xp),
+      xp_adjustment: sum(a.xp_adjustment)
     })
   end
 

--- a/lib/cadet/assessments/query.ex
+++ b/lib/cadet/assessments/query.ex
@@ -30,6 +30,17 @@ defmodule Cadet.Assessments.Query do
 
   @doc """
   Returns a query with the following bindings:
+  [assessments_with_xp_and_grade, questions]
+  """
+  @spec all_assessments_with_max_xp_and_grade :: Ecto.Query.t()
+  def all_assessments_with_max_xp_and_grade do
+    Assessment
+    |> join(:inner, [a], q in subquery(assessments_max_xp_and_grade()), a.id == q.assessment_id)
+    |> select([a, q], %Assessment{a | max_grade: q.max_grade, max_xp: q.max_xp})
+  end
+
+  @doc """
+  Returns a query with the following bindings:
   [assessments_with_grade, questions]
   """
   @spec all_assessments_with_max_grade :: Ecto.Query.t()
@@ -66,5 +77,16 @@ defmodule Cadet.Assessments.Query do
     Question
     |> group_by(:assessment_id)
     |> select([q], %{assessment_id: q.assessment_id, max_grade: sum(q.max_grade)})
+  end
+
+  @spec assessments_max_xp_and_grade :: Ecto.Query.t()
+  def assessments_max_xp_and_grade do
+    Question
+    |> group_by(:assessment_id)
+    |> select([q], %{
+      assessment_id: q.assessment_id,
+      max_grade: sum(q.max_grade),
+      max_xp: sum(q.max_xp)
+    })
   end
 end

--- a/lib/cadet/assessments/question.ex
+++ b/lib/cadet/assessments/question.ex
@@ -22,7 +22,7 @@ defmodule Cadet.Assessments.Question do
   end
 
   @required_fields ~w(question type assessment_id)a
-  @optional_fields ~w(display_order max_grade)a
+  @optional_fields ~w(display_order max_grade max_xp)a
   @required_embeds ~w(library)a
 
   def changeset(question, params) do

--- a/lib/cadet/assessments/question.ex
+++ b/lib/cadet/assessments/question.ex
@@ -13,6 +13,7 @@ defmodule Cadet.Assessments.Question do
     field(:question, :map)
     field(:type, QuestionType)
     field(:max_grade, :integer)
+    field(:max_xp, :integer)
     field(:answer, :map, virtual: true)
     embeds_one(:library, Library)
     embeds_one(:grading_library, Library)

--- a/lib/cadet/assessments/submission.ex
+++ b/lib/cadet/assessments/submission.ex
@@ -8,6 +8,7 @@ defmodule Cadet.Assessments.Submission do
   schema "submissions" do
     field(:grade, :integer, virtual: true)
     field(:adjustment, :integer, virtual: true)
+    field(:xp_bonus, :integer, default: 0)
     field(:status, SubmissionStatus, default: :attempting)
 
     belongs_to(:assessment, Assessment)
@@ -18,10 +19,17 @@ defmodule Cadet.Assessments.Submission do
   end
 
   @required_fields ~w(student_id assessment_id status)a
+  @optional_fields ~w(xp_bonus)a
+  @xp_early_submission_bonus 100
 
   def changeset(submission, params) do
     submission
-    |> cast(params, @required_fields)
+    |> cast(params, @required_fields ++ @optional_fields)
+    |> validate_number(
+      :xp_bonus,
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: @xp_early_submission_bonus
+    )
     |> add_belongs_to_id_from_model([:student, :assessment], params)
     |> validate_required(@required_fields)
     |> foreign_key_constraint(:student_id)

--- a/lib/cadet/assessments/submission.ex
+++ b/lib/cadet/assessments/submission.ex
@@ -22,7 +22,7 @@ defmodule Cadet.Assessments.Submission do
 
   @required_fields ~w(student_id assessment_id status)a
   @optional_fields ~w(xp_bonus)a
-  @xp_early_submission_bonus 100
+  @xp_early_submission_max_bonus 100
 
   def changeset(submission, params) do
     submission
@@ -30,7 +30,7 @@ defmodule Cadet.Assessments.Submission do
     |> validate_number(
       :xp_bonus,
       greater_than_or_equal_to: 0,
-      less_than_or_equal_to: @xp_early_submission_bonus
+      less_than_or_equal_to: @xp_early_submission_max_bonus
     )
     |> add_belongs_to_id_from_model([:student, :assessment], params)
     |> validate_required(@required_fields)

--- a/lib/cadet/assessments/submission.ex
+++ b/lib/cadet/assessments/submission.ex
@@ -8,6 +8,8 @@ defmodule Cadet.Assessments.Submission do
   schema "submissions" do
     field(:grade, :integer, virtual: true)
     field(:adjustment, :integer, virtual: true)
+    field(:xp, :integer, virtual: true)
+    field(:xp_adjustment, :integer, virtual: true)
     field(:xp_bonus, :integer, default: 0)
     field(:status, SubmissionStatus, default: :attempting)
 

--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -119,7 +119,7 @@ defmodule Cadet.Autograder.GradingJob do
 
     grade = if answer.answer["choice_id"] == correct_choice, do: question.max_grade, else: 0
 
-    xp_addition =
+    xp =
       if question.max_grade == 0,
         do: 0,
         else: Integer.floor_div(question.max_xp * grade, question.max_grade)
@@ -127,7 +127,7 @@ defmodule Cadet.Autograder.GradingJob do
     answer
     |> Answer.autograding_changeset(%{
       grade: grade,
-      xp: answer.xp + xp_addition,
+      xp: xp,
       autograding_status: :success
     })
     |> Repo.update()

--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -119,8 +119,17 @@ defmodule Cadet.Autograder.GradingJob do
 
     grade = if answer.answer["choice_id"] == correct_choice, do: question.max_grade, else: 0
 
+    xp_addition =
+      if question.max_grade == 0,
+        do: 0,
+        else: Integer.floor_div(question.max_xp * grade, question.max_grade)
+
     answer
-    |> Answer.autograding_changeset(%{grade: grade, autograding_status: :success})
+    |> Answer.autograding_changeset(%{
+      grade: grade,
+      xp: answer.xp + xp_addition,
+      autograding_status: :success
+    })
     |> Repo.update()
   end
 

--- a/lib/cadet/jobs/autograder/result_store_worker.ex
+++ b/lib/cadet/jobs/autograder/result_store_worker.ex
@@ -49,7 +49,7 @@ defmodule Cadet.Autograder.ResultStoreWorker do
   end
 
   defp update_answer(answer = %Answer{}, result = %{status: status}) do
-    xp_addition =
+    xp =
       if answer.question.max_grade == 0 do
         0
       else
@@ -59,7 +59,7 @@ defmodule Cadet.Autograder.ResultStoreWorker do
     changes = %{
       adjustment: 0,
       grade: result.grade,
-      xp: answer.xp + xp_addition,
+      xp: xp,
       autograding_status: status,
       autograding_errors: result.errors
     }

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -197,6 +197,7 @@ defmodule Cadet.Updater.XMLParser do
         ~x"//PROBLEMS/PROBLEM"el,
         type: ~x"./@type"o |> transform_by(&process_charlist/1),
         max_grade: ~x"./@maxgrade"oi,
+        max_xp: ~x"./@maxxp"oi,
         entity: ~x"."
       )
       |> Enum.map(fn param ->

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -124,6 +124,10 @@ defmodule CadetWeb.AssessmentsController do
               required: true
             )
 
+            xp(:integer, "The xp earned for this assessment", required: true)
+
+            grade(:integer, "The grade earned for this assessment", required: true)
+
             coverImage(:string, "The URL to the cover picture", required: true)
           end
         end,

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -118,6 +118,12 @@ defmodule CadetWeb.AssessmentsController do
               required: true
             )
 
+            maxXp(
+              :integer,
+              "The maximum xp for this assessment",
+              required: true
+            )
+
             coverImage(:string, "The URL to the cover picture", required: true)
           end
         end,

--- a/lib/cadet_web/controllers/user_controller.ex
+++ b/lib/cadet_web/controllers/user_controller.ex
@@ -57,7 +57,11 @@ defmodule CadetWeb.UserController do
 
             story(Schema.ref(:UserStory), "Story to displayed to current user. ")
 
-            grade(:integer, "Amount of grade. Only provided for 'Student'")
+            grade(
+              :integer,
+              "Amount of grade. Only provided for 'Student'." <>
+                "Value will be 0 for non-students."
+            )
 
             maxGrade(
               :integer,
@@ -65,7 +69,10 @@ defmodule CadetWeb.UserController do
                 "Only provided for 'Student'"
             )
 
-            xp(:integer, "Amount of xp. Only provided for 'Student'")
+            xp(
+              :integer,
+              "Amount of xp. Only provided for 'Student'." <> "Value will be 0 for non-students."
+            )
           end
         end,
       UserStory:

--- a/lib/cadet_web/controllers/user_controller.ex
+++ b/lib/cadet_web/controllers/user_controller.ex
@@ -13,7 +13,17 @@ defmodule CadetWeb.UserController do
     grade = user_total_grade(user)
     max_grade = user_max_grade(user)
     story = user_current_story(user)
-    render(conn, "index.json", user: user, grade: grade, max_grade: max_grade, story: story)
+    xp = user_total_xp(user)
+
+    render(
+      conn,
+      "index.json",
+      user: user,
+      grade: grade,
+      max_grade: max_grade,
+      story: story,
+      xp: xp
+    )
   end
 
   swagger_path :index do
@@ -54,6 +64,8 @@ defmodule CadetWeb.UserController do
               "Total maximum grade achievable based on submitted assessments." <>
                 "Only provided for 'Student'"
             )
+
+            xp(:integer, "Amount of xp. Only provided for 'Student'")
           end
         end,
       UserStory:

--- a/lib/cadet_web/views/assessments_view.ex
+++ b/lib/cadet_web/views/assessments_view.ex
@@ -21,6 +21,7 @@ defmodule CadetWeb.AssessmentsView do
       reading: :reading,
       status: &(&1.user_status || "not_attempted"),
       maxGrade: :max_grade,
+      maxXp: :max_xp,
       coverImage: :cover_picture
     })
   end

--- a/lib/cadet_web/views/assessments_view.ex
+++ b/lib/cadet_web/views/assessments_view.ex
@@ -22,6 +22,8 @@ defmodule CadetWeb.AssessmentsView do
       status: &(&1.user_status || "not_attempted"),
       maxGrade: :max_grade,
       maxXp: :max_xp,
+      xp: &(&1.xp || 0),
+      grade: &(&1.grade || 0),
       coverImage: :cover_picture
     })
   end

--- a/lib/cadet_web/views/assessments_view.ex
+++ b/lib/cadet_web/views/assessments_view.ex
@@ -22,7 +22,7 @@ defmodule CadetWeb.AssessmentsView do
       status: &(&1.user_status || "not_attempted"),
       maxGrade: :max_grade,
       maxXp: :max_xp,
-      xp: &(&1.xp || 0),
+      xp: :xp,
       grade: &(&1.grade || 0),
       coverImage: :cover_picture
     })

--- a/lib/cadet_web/views/grading_view.ex
+++ b/lib/cadet_web/views/grading_view.ex
@@ -12,6 +12,8 @@ defmodule CadetWeb.GradingView do
   def render("submission.json", %{submission: submission}) do
     transform_map_for_view(submission, %{
       grade: :grade,
+      xp: :xp,
+      xpAdjustment: :xp_adjustment,
       adjustment: :adjustment,
       id: :id,
       student: &transform_map_for_view(&1.student, [:name, :id]),
@@ -19,6 +21,7 @@ defmodule CadetWeb.GradingView do
         &transform_map_for_view(&1.assessment, %{
           type: :type,
           maxGrade: :max_grade,
+          maxXp: :max_xp,
           id: :id,
           title: :title,
           coverImage: :cover_picture
@@ -34,9 +37,17 @@ defmodule CadetWeb.GradingView do
           :answer,
           &1.answer["code"] || &1.answer["choice_id"]
         ),
-      maxGrade: & &1.question.max_grade,
       solution: &(&1.question.question["solution"] || ""),
-      grade: &transform_map_for_view(&1, [:grade, :adjustment, :comment])
+      maxGrade: & &1.question.max_grade,
+      maxXp: & &1.question.max_xp,
+      grade:
+        &transform_map_for_view(&1, %{
+          grade: :grade,
+          adjustment: :adjustment,
+          comment: :comment,
+          xp: :xp,
+          xpAdjustment: :xp_adjustment
+        })
     })
   end
 end

--- a/lib/cadet_web/views/user_view.ex
+++ b/lib/cadet_web/views/user_view.ex
@@ -1,11 +1,12 @@
 defmodule CadetWeb.UserView do
   use CadetWeb, :view
 
-  def render("index.json", %{user: user, grade: grade, max_grade: max_grade, story: story}) do
+  def render("index.json", %{user: user, grade: grade, max_grade: max_grade, xp: xp, story: story}) do
     %{
       name: user.name,
       role: user.role,
       grade: grade,
+      xp: xp,
       maxGrade: max_grade,
       story:
         transform_map_for_view(story, %{

--- a/priv/repo/migrations/20180818060805_add_xp_to_assessments.exs
+++ b/priv/repo/migrations/20180818060805_add_xp_to_assessments.exs
@@ -6,9 +6,12 @@ defmodule Cadet.Repo.Migrations.AddXpToAssessments do
       add(:max_xp, :integer, default: 0)
     end
 
+    alter table(:submissions) do
+      add(:xp_bonus, :integer, default: 0)
+    end
+
     alter table(:answers) do
       add(:xp, :integer, default: 0)
-      add(:xp_bonus, :integer, default: 0)
       add(:xp_adjustment, :integer, default: 0)
     end
   end

--- a/priv/repo/migrations/20180818060805_add_xp_to_assessments.exs
+++ b/priv/repo/migrations/20180818060805_add_xp_to_assessments.exs
@@ -1,0 +1,13 @@
+defmodule Cadet.Repo.Migrations.AddXpToAssessments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:questions) do
+      add(:max_xp, :integer, default: 0)
+    end
+
+    alter table(:answers) do
+      add(:xp, :integer, default: 0)
+    end
+  end
+end

--- a/priv/repo/migrations/20180818060805_add_xp_to_assessments.exs
+++ b/priv/repo/migrations/20180818060805_add_xp_to_assessments.exs
@@ -8,6 +8,7 @@ defmodule Cadet.Repo.Migrations.AddXpToAssessments do
 
     alter table(:answers) do
       add(:xp, :integer, default: 0)
+      add(:xp_bonus, :integer, default: 0)
       add(:xp_adjustment, :integer, default: 0)
     end
   end

--- a/priv/repo/migrations/20180818060805_add_xp_to_assessments.exs
+++ b/priv/repo/migrations/20180818060805_add_xp_to_assessments.exs
@@ -8,6 +8,7 @@ defmodule Cadet.Repo.Migrations.AddXpToAssessments do
 
     alter table(:answers) do
       add(:xp, :integer, default: 0)
+      add(:xp_adjustment, :integer, default: 0)
     end
   end
 end

--- a/priv/repo/migrations/20180821164317_add_index_on_student_id_in_submission.exs
+++ b/priv/repo/migrations/20180821164317_add_index_on_student_id_in_submission.exs
@@ -1,0 +1,7 @@
+defmodule Cadet.Repo.Migrations.AddIndexOnStudentIdInSubmission do
+  use Ecto.Migration
+
+  def change do
+    create(index(:submissions, :student_id))
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -28,13 +28,15 @@ if Application.get_env(:cadet, :environment) == :dev do
     programming_questions =
       insert_list(3, :programming_question, %{
         assessment: assessment,
-        max_grade: 200
+        max_grade: 200,
+        max_xp: 1_000
       })
 
     mcq_questions =
       insert_list(3, :mcq_question, %{
         assessment: assessment,
-        max_grade: 40
+        max_grade: 40,
+        max_xp: 500
       })
 
     submissions =
@@ -53,6 +55,7 @@ if Application.get_env(:cadet, :environment) == :dev do
         question <- programming_questions do
       insert(:answer, %{
         grade: Enum.random(0..200),
+        xp: Enum.random(0..1_000),
         question: question,
         submission: submission,
         answer: build(:programming_answer)
@@ -64,6 +67,7 @@ if Application.get_env(:cadet, :environment) == :dev do
         question <- mcq_questions do
       insert(:answer, %{
         grade: Enum.random(0..40),
+        xp: Enum.random(0..500),
         question: question,
         submission: submission,
         answer: build(:mcq_answer)

--- a/test/cadet/jobs/autograder/grading_job_test.exs
+++ b/test/cadet/jobs/autograder/grading_job_test.exs
@@ -311,6 +311,7 @@ defmodule Cadet.Autograder.GradingJobTest do
 
         for answer <- inserted_empty_answers do
           assert answer.grade == 0
+          assert answer.xp == 0
           assert answer.autograding_status == :success
           assert answer.answer == %{"code" => "// Question not answered by student."}
           assert answer.comment == "Question not attempted by student"
@@ -361,6 +362,7 @@ defmodule Cadet.Autograder.GradingJobTest do
 
       for answer <- answers do
         assert answer.grade == 0
+        assert answer.xp == 0
         assert answer.autograding_status == :success
         assert answer.answer == %{"choice_id" => 0}
         assert answer.comment == "Question not attempted by student"
@@ -408,8 +410,10 @@ defmodule Cadet.Autograder.GradingJobTest do
         # seeded questions have correct choice as 0
         if answer_db.answer["choice_id"] == 0 do
           assert answer_db.grade == question.max_grade
+          assert answer_db.xp == question.max_xp
         else
           assert answer_db.grade == 0
+          assert answer_db.xp == 0
         end
 
         assert answer_db.autograding_status == :success

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -15,7 +15,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
     Cadet.Test.Seeds.assessments()
   end
 
-  @xp_early_submission_bonus 100
+  @xp_early_submission_max_bonus 100
   @xp_bonus_assessment_type ~w(mission sidequest)a
 
   test "swagger" do
@@ -625,7 +625,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
           submission_db = Repo.get(Submission, submission.id)
 
           assert submission_db.status == :submitted
-          assert submission_db.xp_bonus == @xp_early_submission_bonus
+          assert submission_db.xp_bonus == @xp_early_submission_max_bonus
         end
       end
     end
@@ -665,7 +665,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
           submission_db = Repo.get(Submission, submission.id)
 
           assert submission_db.status == :submitted
-          assert submission_db.xp_bonus == @xp_early_submission_bonus - (hours_after - 48)
+          assert submission_db.xp_bonus == @xp_early_submission_max_bonus - (hours_after - 48)
         end
       end
     end

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -61,7 +61,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "type" => "#{&1.type}",
               "coverImage" => &1.cover_picture,
               "maxGrade" => 720,
-              "maxXp" => 600,
+              "maxXp" => 4500,
               "status" => get_assessment_status(user, &1)
             }
           )
@@ -71,6 +71,8 @@ defmodule CadetWeb.AssessmentsControllerTest do
           |> sign_in(user)
           |> get(build_url())
           |> json_response(200)
+          |> Enum.map(&Map.delete(&1, "xp"))
+          |> Enum.map(&Map.delete(&1, "grade"))
 
         assert expected == resp
       end
@@ -108,7 +110,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "type" => "#{&1.type}",
               "coverImage" => &1.cover_picture,
               "maxGrade" => 720,
-              "maxXp" => 600,
+              "maxXp" => 4500,
               "status" => get_assessment_status(user, &1)
             }
           )
@@ -118,6 +120,8 @@ defmodule CadetWeb.AssessmentsControllerTest do
           |> sign_in(user)
           |> get(build_url())
           |> json_response(200)
+          |> Enum.map(&Map.delete(&1, "xp"))
+          |> Enum.map(&Map.delete(&1, "grade"))
 
         assert expected == resp
       end
@@ -148,6 +152,42 @@ defmodule CadetWeb.AssessmentsControllerTest do
 
         assert get_assessment_status(student, assessment) == resp
       end
+    end
+
+    test "renders xp for students", %{
+      conn: conn,
+      users: %{student: student},
+      assessments: assessments
+    } do
+      assessment = assessments.mission.assessment
+
+      resp =
+        conn
+        |> sign_in(student)
+        |> get(build_url())
+        |> json_response(200)
+        |> Enum.find(&(&1["id"] == assessment.id))
+        |> Map.get("xp")
+
+      assert resp == 1000 * 3 + 500 * 3
+    end
+
+    test "renders grade for students", %{
+      conn: conn,
+      users: %{student: student},
+      assessments: assessments
+    } do
+      assessment = assessments.mission.assessment
+
+      resp =
+        conn
+        |> sign_in(student)
+        |> get(build_url())
+        |> json_response(200)
+        |> Enum.find(&(&1["id"] == assessment.id))
+        |> Map.get("grade")
+
+      assert resp == 200 * 3 + 40 * 3
     end
   end
 

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -61,6 +61,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "type" => "#{&1.type}",
               "coverImage" => &1.cover_picture,
               "maxGrade" => 720,
+              "maxXp" => 600,
               "status" => get_assessment_status(user, &1)
             }
           )
@@ -107,6 +108,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "type" => "#{&1.type}",
               "coverImage" => &1.cover_picture,
               "maxGrade" => 720,
+              "maxXp" => 600,
               "status" => get_assessment_status(user, &1)
             }
           )

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -222,7 +222,11 @@ defmodule CadetWeb.GradingControllerTest do
 
       conn =
         post(conn, build_url(answer.submission.id, answer.question.id), %{
-          "grading" => %{"adjustment" => -10, "comment" => "Never gonna give you up"}
+          "grading" => %{
+            "adjustment" => -10,
+            "comment" => "Never gonna give you up",
+            "xpAdjustment" => -10
+          }
         })
 
       assert response(conn, 200) == "OK"
@@ -230,7 +234,7 @@ defmodule CadetWeb.GradingControllerTest do
     end
 
     @tag authenticate: :staff
-    test "invalid param fails", %{conn: conn} do
+    test "invalid adjustment fails", %{conn: conn} do
       %{answers: answers} = seed_db(conn)
 
       answer = List.first(answers)
@@ -242,6 +246,21 @@ defmodule CadetWeb.GradingControllerTest do
 
       assert response(conn, 400) ==
                "adjustment must make total be between 0 and question.max_grade"
+    end
+
+    @tag authenticate: :staff
+    test "invalid xp_adjustment fails", %{conn: conn} do
+      %{answers: answers} = seed_db(conn)
+
+      answer = List.first(answers)
+
+      conn =
+        post(conn, build_url(answer.submission.id, answer.question.id), %{
+          "grading" => %{"xpAdjustment" => -9_999_999_999}
+        })
+
+      assert response(conn, 400) ==
+               "xp_adjustment must make total be between 0 and question.max_xp"
     end
 
     @tag authenticate: :staff

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -76,6 +76,8 @@ defmodule CadetWeb.GradingControllerTest do
       expected =
         Enum.map(submissions, fn submission ->
           %{
+            "xp" => 4000,
+            "xpAdjustment" => -2000,
             "grade" => 800,
             "adjustment" => -400,
             "id" => submission.id,
@@ -86,6 +88,7 @@ defmodule CadetWeb.GradingControllerTest do
             "assessment" => %{
               "type" => "mission",
               "maxGrade" => 800,
+              "maxXp" => 4000,
               "id" => mission.id,
               "title" => mission.title,
               "coverImage" => mission.cover_picture
@@ -146,10 +149,13 @@ defmodule CadetWeb.GradingControllerTest do
                 },
                 "solution" => &1.question.question.solution,
                 "maxGrade" => &1.question.max_grade,
+                "maxXp" => &1.question.max_xp,
                 "grade" => %{
                   "grade" => &1.grade,
                   "adjustment" => &1.adjustment,
-                  "comment" => &1.comment
+                  "comment" => &1.comment,
+                  "xp" => &1.xp,
+                  "xpAdjustment" => &1.xp_adjustment
                 }
               }
 
@@ -179,10 +185,13 @@ defmodule CadetWeb.GradingControllerTest do
                 },
                 "solution" => "",
                 "maxGrade" => &1.question.max_grade,
+                "maxXp" => &1.question.max_xp,
                 "grade" => %{
                   "grade" => &1.grade,
                   "adjustment" => &1.adjustment,
-                  "comment" => &1.comment
+                  "comment" => &1.comment,
+                  "xp" => &1.xp,
+                  "xpAdjustment" => &1.xp_adjustment
                 }
               }
           end
@@ -308,6 +317,7 @@ defmodule CadetWeb.GradingControllerTest do
         insert(:programming_question, %{
           assessment: mission,
           max_grade: 200,
+          max_xp: 1000,
           display_order: 4 - index
         })
       end ++
@@ -315,6 +325,7 @@ defmodule CadetWeb.GradingControllerTest do
           insert(:mcq_question, %{
             assessment: mission,
             max_grade: 200,
+            max_xp: 1000,
             display_order: 1
           })
         ]
@@ -330,6 +341,8 @@ defmodule CadetWeb.GradingControllerTest do
         insert(:answer, %{
           grade: 200,
           adjustment: -100,
+          xp: 1000,
+          xp_adjustment: -500,
           question: question,
           submission: submission,
           answer:

--- a/test/cadet_web/controllers/user_controller_test.exs
+++ b/test/cadet_web/controllers/user_controller_test.exs
@@ -20,9 +20,21 @@ defmodule CadetWeb.UserControllerTest do
       question = insert(:question, %{assessment: assessment})
 
       submission =
-        insert(:submission, %{assessment: assessment, student: user, status: :submitted})
+        insert(:submission, %{
+          assessment: assessment,
+          student: user,
+          status: :submitted,
+          xp_bonus: 100
+        })
 
-      insert(:answer, %{question: question, submission: submission, grade: 50, adjustment: -10})
+      insert(:answer, %{
+        question: question,
+        submission: submission,
+        grade: 50,
+        adjustment: -10,
+        xp: 20,
+        xp_adjustment: -10
+      })
 
       not_submitted_assessment = insert(:assessment, is_published: true)
       not_submitted_question = insert(:question, assessment: not_submitted_assessment)
@@ -47,6 +59,7 @@ defmodule CadetWeb.UserControllerTest do
       expected = %{
         "name" => user.name,
         "role" => "#{user.role}",
+        "xp" => 110,
         "grade" => 40,
         "maxGrade" => question.max_grade
       }
@@ -194,7 +207,13 @@ defmodule CadetWeb.UserControllerTest do
         |> json_response(200)
         |> Map.delete("story")
 
-      expected = %{"name" => user.name, "role" => "#{user.role}", "grade" => 0, "maxGrade" => 0}
+      expected = %{
+        "name" => user.name,
+        "role" => "#{user.role}",
+        "grade" => 0,
+        "maxGrade" => 0,
+        "xp" => 0
+      }
 
       assert expected == resp
     end

--- a/test/factories/assessments/question_factory.ex
+++ b/test/factories/assessments/question_factory.ex
@@ -17,6 +17,7 @@ defmodule Cadet.Assessments.QuestionFactory do
         %Question{
           type: :programming,
           max_grade: 10,
+          max_xp: 100,
           assessment: build(:assessment, %{is_published: true}),
           library: library,
           grading_library: Enum.random([build(:library), library]),
@@ -42,6 +43,7 @@ defmodule Cadet.Assessments.QuestionFactory do
         %Question{
           type: :mcq,
           max_grade: 10,
+          max_xp: 100,
           assessment: build(:assessment, %{is_published: true}),
           library: build(:library),
           grading_library: Enum.random([build(:library), library]),

--- a/test/support/seeds.ex
+++ b/test/support/seeds.ex
@@ -79,7 +79,8 @@ defmodule Cadet.Test.Seeds do
         insert(:programming_question, %{
           display_order: id,
           assessment: assessment,
-          max_grade: 200
+          max_grade: 200,
+          max_xp: 1000
         })
       end)
 
@@ -88,7 +89,8 @@ defmodule Cadet.Test.Seeds do
         insert(:mcq_question, %{
           display_order: id,
           assessment: assessment,
-          max_grade: 40
+          max_grade: 40,
+          max_xp: 500
         })
       end)
 
@@ -103,6 +105,7 @@ defmodule Cadet.Test.Seeds do
         Enum.map(programming_questions, fn question ->
           insert(:answer, %{
             grade: 200,
+            xp: 1000,
             question: question,
             submission: submission,
             answer: build(:programming_answer)
@@ -115,6 +118,7 @@ defmodule Cadet.Test.Seeds do
         Enum.map(mcq_questions, fn question ->
           insert(:answer, %{
             grade: 40,
+            xp: 500,
             question: question,
             submission: submission,
             answer: build(:mcq_answer)


### PR DESCRIPTION
## XP Document
- [x] each mission will have a max #XP, and XP will scale according to the grade achieved
- [x] Each quest will have a max #XP, and XP will scale according to the test cases passed. 
- [x] Paths: Fixed #XP max per path, autograded in the Academy
- [x] Early completion bonuses. Assuming every mission/quest has a flat 100 XP decaying, Decays starting 2 days from opening. 1 XP per hour. No XP after ~6 days.

Implied
- [x] No bonus xp for quest/path

## Implement Endpoint
- [x] `User`, add `total_xp`
- [x] `Grading`, add `xp`, `xp_bonus`, `xp_adjustment`
- [x] `Assessment`, add `max_xp`, `xp`, `grade`

## File issue in other repos
- [x] XML spec in `cs1101s`
- [x] Frontend to add/hook up the additional endpoints (https://github.com/source-academy/cadet-frontend/issues/316)