### PR TITLE
Allow for Batch Grading Process

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -16,7 +16,6 @@ defmodule Cadet.Assessments do
   @xp_bonus_assessment_type ~w(mission sidequest)a
   @submit_answer_roles ~w(student)a
   @grading_roles ~w()a
-  @admin_role :admin
   @see_all_submissions_roles [:staff, :admin]
   @open_all_assessment_roles ~w(staff admin)a
 
@@ -465,7 +464,7 @@ defmodule Cadet.Assessments do
 
       role in @see_all_submissions_roles ->
         submissions =
-          if group_only && role != @admin_role do
+          if group_only do
             submissions_by_group(grader, submission_query)
           else
             Repo.all(submission_query)
@@ -629,11 +628,15 @@ defmodule Cadet.Assessments do
     end
   end
 
-  defp submissions_by_group(grader, submission_query) do
+  defp submissions_by_group(grader = %User{role: :staff}, submission_query) do
     students = Cadet.Accounts.Query.students_of(grader)
 
     submission_query
     |> join(:inner, [s], st in subquery(students), s.student_id == st.id)
     |> Repo.all()
+  end
+
+  defp submissions_by_group(%User{role: :admin}, submission_query) do
+    Repo.all(submission_query)
   end
 end

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -566,8 +566,7 @@ defmodule Cadet.Assessments do
         _,
         _,
         _
-      )
-      when is_ecto_id(submission_id) and is_ecto_id(question_id) do
+      ) do
     {:error, {:unauthorized, "User is not permitted to grade."}}
   end
 

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -468,9 +468,9 @@ defmodule Cadet.Assessments do
 
     if role in @see_all_submissions_roles do
       answers =
-          answer_query
-          |> Repo.all()
-          |> Enum.sort_by(& &1.question.display_order)
+        answer_query
+        |> Repo.all()
+        |> Enum.sort_by(& &1.question.display_order)
 
       {:ok, answers}
     else

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -563,7 +563,7 @@ defmodule Cadet.Assessments do
   end
 
   def update_grading_info(
-        %{submission_id: submission_id, question_id: question_id},
+        _,
         _,
         _
       )

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -513,11 +513,15 @@ defmodule Cadet.Assessments do
             answer_query
             |> join(:inner, [a], s in assoc(a, :submission))
             |> join(:inner, [a, s], t in subquery(students), t.id == s.student_id)
+            |> Repo.one()
 
           role in @see_all_submissions_roles ->
             answer_query
+            |> Repo.one()
+
+          true ->
+            []
         end
-        |> Repo.one()
 
       with {:answer_found?, true} <- {:answer_found?, is_map(answer)},
            {:valid, changeset = %Ecto.Changeset{valid?: true}} <-

--- a/lib/cadet_web/controllers/grading_controller.ex
+++ b/lib/cadet_web/controllers/grading_controller.ex
@@ -78,7 +78,7 @@ defmodule CadetWeb.GradingController do
   swagger_path :index do
     get("/grading")
 
-    summary("Get a list of all submissions")
+    summary("Get a list of all submissions with current user as the grader.")
 
     security([%{JWT: []}])
 

--- a/lib/cadet_web/controllers/grading_controller.ex
+++ b/lib/cadet_web/controllers/grading_controller.ex
@@ -88,7 +88,7 @@ defmodule CadetWeb.GradingController do
   swagger_path :index do
     get("/grading")
 
-    summary("Get a list of all submissions with current user as the grader. ")
+    summary("Get a list of all submissions")
 
     security([%{JWT: []}])
 
@@ -113,6 +113,19 @@ defmodule CadetWeb.GradingController do
 
     response(200, "OK", Schema.ref(:GradingInfo))
     response(400, "Invalid or missing parameter(s) or submission and/or question not found")
+    response(401, "Unauthorised")
+  end
+
+  swagger_path :group do
+    get("/group")
+
+    summary("Get a list of all submissions with current user as the grader. ")
+
+    security([%{JWT: []}])
+
+    produces("application/json")
+
+    response(200, "OK", Schema.ref(:Submissions))
     response(401, "Unauthorised")
   end
 

--- a/lib/cadet_web/controllers/grading_controller.ex
+++ b/lib/cadet_web/controllers/grading_controller.ex
@@ -4,7 +4,7 @@ defmodule CadetWeb.GradingController do
 
   alias Cadet.Assessments
 
-  def index(conn, %{"group" => group}) do
+  def index(conn, %{"group" => group}) when is_boolean(group) do
     user = conn.assigns[:current_user]
 
     case Assessments.all_submissions_by_grader(user, group) do
@@ -19,17 +19,7 @@ defmodule CadetWeb.GradingController do
   end
 
   def index(conn, _) do
-    user = conn.assigns[:current_user]
-
-    case Assessments.all_submissions_by_grader(user) do
-      {:ok, submissions} ->
-        render(conn, "index.json", submissions: submissions)
-
-      {:error, {status, message}} ->
-        conn
-        |> put_status(status)
-        |> text(message)
-    end
+    index(conn, %{"group" => false})
   end
 
   def show(conn, %{"submissionid" => submission_id}) when is_ecto_id(submission_id) do
@@ -95,7 +85,12 @@ defmodule CadetWeb.GradingController do
     produces("application/json")
 
     parameters do
-      group(:body, :boolean, "Boolean to show group under grader", required: false)
+      group(
+        :body,
+        :boolean,
+        "Show only students in the grader's group when true",
+        required: false
+      )
     end
 
     response(200, "OK", Schema.ref(:Submissions))

--- a/lib/cadet_web/controllers/grading_controller.ex
+++ b/lib/cadet_web/controllers/grading_controller.ex
@@ -4,6 +4,20 @@ defmodule CadetWeb.GradingController do
 
   alias Cadet.Assessments
 
+  def index(conn, %{"group" => group}) do
+    user = conn.assigns[:current_user]
+
+    case Assessments.all_submissions_by_grader(user, group) do
+      {:ok, submissions} ->
+        render(conn, "index.json", submissions: submissions)
+
+      {:error, {status, message}} ->
+        conn
+        |> put_status(status)
+        |> text(message)
+    end
+  end
+
   def index(conn, _) do
     user = conn.assigns[:current_user]
 
@@ -69,20 +83,6 @@ defmodule CadetWeb.GradingController do
     conn
     |> put_status(:bad_request)
     |> text("Missing parameter")
-  end
-
-  def group(conn, _) do
-    user = conn.assigns[:current_user]
-
-    case Assessments.all_submissions_by_grader(user, true) do
-      {:ok, submissions} ->
-        render(conn, "index.json", submissions: submissions)
-
-      {:error, {status, message}} ->
-        conn
-        |> put_status(status)
-        |> text(message)
-    end
   end
 
   swagger_path :index do

--- a/lib/cadet_web/controllers/grading_controller.ex
+++ b/lib/cadet_web/controllers/grading_controller.ex
@@ -71,6 +71,20 @@ defmodule CadetWeb.GradingController do
     |> text("Missing parameter")
   end
 
+  def group(conn, _) do
+    user = conn.assigns[:current_user]
+
+    case Assessments.all_submissions_by_grader(user, true) do
+      {:ok, submissions} ->
+        render(conn, "index.json", submissions: submissions)
+
+      {:error, {status, message}} ->
+        conn
+        |> put_status(status)
+        |> text(message)
+    end
+  end
+
   swagger_path :index do
     get("/grading")
 

--- a/lib/cadet_web/controllers/grading_controller.ex
+++ b/lib/cadet_web/controllers/grading_controller.ex
@@ -94,6 +94,10 @@ defmodule CadetWeb.GradingController do
 
     produces("application/json")
 
+    parameters do
+      group(:body, :boolean, "Boolean to show group under grader", required: false)
+    end
+
     response(200, "OK", Schema.ref(:Submissions))
     response(401, "Unauthorised")
   end
@@ -113,19 +117,6 @@ defmodule CadetWeb.GradingController do
 
     response(200, "OK", Schema.ref(:GradingInfo))
     response(400, "Invalid or missing parameter(s) or submission and/or question not found")
-    response(401, "Unauthorised")
-  end
-
-  swagger_path :group do
-    get("/group")
-
-    summary("Get a list of all submissions with current user as the grader. ")
-
-    security([%{JWT: []}])
-
-    produces("application/json")
-
-    response(200, "OK", Schema.ref(:Submissions))
     response(401, "Unauthorised")
   end
 

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -38,6 +38,8 @@ defmodule CadetWeb.Router do
     post("/grading/:submissionid/:questionid", GradingController, :update)
 
     get("/user", UserController, :index)
+
+    get("/group", GradingController, :group)
   end
 
   # Other scopes may use custom stacks.

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -38,8 +38,6 @@ defmodule CadetWeb.Router do
     post("/grading/:submissionid/:questionid", GradingController, :update)
 
     get("/user", UserController, :index)
-
-    get("/group", GradingController, :group)
   end
 
   # Other scopes may use custom stacks.

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -555,7 +555,7 @@ defmodule CadetWeb.GradingControllerTest do
         submissions: submissions
       } = seed_db(conn)
 
-      conn = get(conn, build_url_group())
+      conn = get(conn, build_url(), %{"group" => true})
 
       expected =
         Enum.map(submissions, fn submission ->
@@ -587,8 +587,6 @@ defmodule CadetWeb.GradingControllerTest do
   defp build_url, do: "/v1/grading/"
   defp build_url(submission_id), do: "#{build_url()}#{submission_id}/"
   defp build_url(submission_id, question_id), do: "#{build_url(submission_id)}#{question_id}"
-
-  defp build_url_group, do: "/v1/group"
 
   defp seed_db(conn) do
     grader = conn.assigns[:current_user]


### PR DESCRIPTION
Addresses Issues #254 and #253 

`/group` endpoint added to show all students under a grader
`/grading` endpoints modified to allow all submissions to be viewed and graded

