### PR TITLE
Grading overview page overhaul (server)

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -201,7 +201,12 @@ defmodule Cadet.Assessments do
         %{
           assessment
           | grading_status:
-              build_grading_status(assessment.user_status, assessment.type, assessment.question_count, assessment.graded_count)
+              build_grading_status(
+                assessment.user_status,
+                assessment.type,
+                assessment.question_count,
+                assessment.graded_count
+              )
         }
       end)
 
@@ -217,7 +222,9 @@ defmodule Cadet.Assessments do
           g_count == q_count -> :graded
           true -> :none
         end
-      _ -> :excluded
+
+      _ ->
+        :excluded
     end
   end
 
@@ -603,7 +610,7 @@ defmodule Cadet.Assessments do
     cond do
       role in @grading_roles ->
         submissions = submissions_by_group(grader, submission_query)
-        
+
         {:ok, build_submission_grading_status(submissions)}
 
       role in @see_all_submissions_roles ->
@@ -625,14 +632,14 @@ defmodule Cadet.Assessments do
   defp build_submission_grading_status(submissions) do
     submissions
     |> Enum.map(fn s = %Submission{} ->
-       %{
+      %{
         s
         | grading_status:
-          build_grading_status(s.status, s.assessment.type, s.question_count, s.graded_count)
-        }
+            build_grading_status(s.status, s.assessment.type, s.question_count, s.graded_count)
+      }
     end)
   end
-  
+
   @spec get_answers_in_submission(integer() | String.t(), %User{}) ::
           {:ok, [%Answer{}]} | {:error, {:unauthorized, String.t()}}
   def get_answers_in_submission(id, grader = %User{role: role}) when is_ecto_id(id) do

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -201,18 +201,23 @@ defmodule Cadet.Assessments do
         %{
           assessment
           | grading_status:
-              build_grading_status(assessment.question_count, assessment.graded_count)
+              build_grading_status(assessment.user_status, assessment.type, assessment.question_count, assessment.graded_count)
         }
       end)
 
     {:ok, assessments}
   end
 
-  defp build_grading_status(q_count, g_count) do
-    cond do
-      g_count < q_count -> :grading
-      g_count == q_count -> :graded
-      true -> :none
+  defp build_grading_status(submission_status, a_type, q_count, g_count) do
+    case a_type do
+      type when type in [:mission, :sidequest] ->
+        cond do
+          submission_status != :submitted -> :excluded
+          g_count < q_count -> :grading
+          g_count == q_count -> :graded
+          true -> :none
+        end
+      _ -> :excluded
     end
   end
 

--- a/lib/cadet/assessments/submission.ex
+++ b/lib/cadet/assessments/submission.ex
@@ -13,6 +13,9 @@ defmodule Cadet.Assessments.Submission do
     field(:xp_bonus, :integer, default: 0)
     field(:group_name, :string, virtual: true)
     field(:status, SubmissionStatus, default: :attempting)
+    field(:question_count, :integer, virtual: true)
+    field(:graded_count, :integer, virtual: true, default: 0)
+    field(:grading_status, :string, virtual: true)
     field(:unsubmitted_at, :utc_datetime_usec)
 
     belongs_to(:assessment, Assessment)

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -114,7 +114,7 @@ defmodule CadetWeb.AssessmentsController do
 
             gradingStatus(
               :string,
-              "one of 'none/grading/graded' indicating whether the assessment has been fully graded",
+              "'excluded' if the assessment does not yet require grading, otherwise one of 'none/grading/graded' indicating the extent to which it has been fully graded",
               required: true
             )
 

--- a/lib/cadet_web/views/assessments_view.ex
+++ b/lib/cadet_web/views/assessments_view.ex
@@ -20,7 +20,7 @@ defmodule CadetWeb.AssessmentsView do
       number: :number,
       reading: :reading,
       status: &(&1.user_status || "not_attempted"),
-      gradingStatus: &(&1.grading_status || "none"),
+      gradingStatus: &(&1.grading_status || "excluded"),
       maxGrade: :max_grade,
       maxXp: :max_xp,
       xp: &(&1.xp || 0),

--- a/lib/cadet_web/views/grading_view.ex
+++ b/lib/cadet_web/views/grading_view.ex
@@ -31,6 +31,9 @@ defmodule CadetWeb.GradingView do
         }),
       groupName: :group_name,
       status: :status,
+      questionCount: :question_count,
+      gradedCount: &(&1.graded_count || 0),
+      gradingStatus: &(&1.grading_status || "excluded"),
       unsubmittedBy: &unsubmitted_by_builder(&1.unsubmitted_by),
       unsubmittedAt: &format_datetime(&1.unsubmitted_at)
     })

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -63,7 +63,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "maxGrade" => 720,
               "maxXp" => 4500,
               "status" => get_assessment_status(user, &1),
-              "gradingStatus" => "none"
+              "gradingStatus" => "excluded"
             }
           )
 
@@ -113,7 +113,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "maxGrade" => 720,
               "maxXp" => 4500,
               "status" => get_assessment_status(user, &1),
-              "gradingStatus" => "none"
+              "gradingStatus" => "excluded"
             }
           )
 

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -119,6 +119,9 @@ defmodule CadetWeb.GradingControllerTest do
             },
             "groupName" => submission.student.group.name,
             "status" => Atom.to_string(submission.status),
+            "questionCount" => 4,
+            "gradedCount" => 4,
+            "gradingStatus" => "excluded",
             "unsubmittedBy" => nil,
             "unsubmittedAt" => nil
           }
@@ -159,6 +162,9 @@ defmodule CadetWeb.GradingControllerTest do
             },
             "groupName" => submission.student.group.name,
             "status" => Atom.to_string(submission.status),
+            "questionCount" => 4,
+            "gradedCount" => 4,
+            "gradingStatus" => "excluded",
             "unsubmittedAt" => nil,
             "unsubmittedBy" => nil
           }
@@ -217,6 +223,9 @@ defmodule CadetWeb.GradingControllerTest do
             },
             "groupName" => submission.student.group.name,
             "status" => Atom.to_string(submission.status),
+            "questionCount" => 4,
+            "gradedCount" => 4,
+            "gradingStatus" => "excluded",
             "unsubmittedAt" => nil,
             "unsubmittedBy" => nil
           }
@@ -809,6 +818,9 @@ defmodule CadetWeb.GradingControllerTest do
             },
             "groupName" => submission.student.group.name,
             "status" => Atom.to_string(submission.status),
+            "questionCount" => 4,
+            "gradedCount" => 4,
+            "gradingStatus" => "excluded",
             "unsubmittedAt" => nil,
             "unsubmittedBy" => nil
           }
@@ -851,6 +863,9 @@ defmodule CadetWeb.GradingControllerTest do
             },
             "groupName" => submission.student.group.name,
             "status" => Atom.to_string(submission.status),
+            "questionCount" => 4,
+            "gradedCount" => 4,
+            "gradingStatus" => "excluded",
             "unsubmittedAt" => nil,
             "unsubmittedBy" => nil
           }


### PR DESCRIPTION
## Grading overview page overhaul (server)
Summary: Changes to support display of grading status for each submission on the frontend.

### Related PRs
Please review this PR in conjunction with the PR on cadet-frontend: https://github.com/source-academy/cadet-frontend/pull/670

### Changelog
   - Added virtuals `question_count`, `graded_count` and `grading_status` fields to `Submission` schema
   - Amend grading status to compute new `:excluded` value for assessments not (yet) requiring manual grading
  - Amend `all_submissions_by_grader` query to build grading status details for each submission with a helper