### PR TITLE
Revert distillery v2.1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,7 @@ defmodule Cadet.Mixfile do
       {:xml_builder, "~> 2.0", override: true},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.2", only: [:dev, :test], runtime: false},
-      {:distillery, "~> 2.1.0", runtime: false},
+      {:distillery, "~> 2.0.14", runtime: false},
       {:excoveralls, "~> 0.8", only: :test},
       {:exvcr, "~> 0.10", only: :test},
       {:faker, "~> 0.10", only: [:dev, :test]},


### PR DESCRIPTION
New version of distillery seems to cause an issue with `mix release`
```
bitnami@ip-172-31-23-146:~/cadet$ MIX_ENV=prod mix release --env=prod
** (Mix) The task "release" could not be found
```