### PR TITLE
Allow graders to grade before autograding

### DIFF
--- a/lib/cadet/jobs/autograder/result_store_worker.ex
+++ b/lib/cadet/jobs/autograder/result_store_worker.ex
@@ -57,7 +57,6 @@ defmodule Cadet.Autograder.ResultStoreWorker do
       end
 
     changes = %{
-      adjustment: 0,
       grade: result.grade,
       xp: xp,
       autograding_status: status,

--- a/test/cadet/jobs/autograder/result_store_worker_test.exs
+++ b/test/cadet/jobs/autograder/result_store_worker_test.exs
@@ -84,7 +84,6 @@ defmodule Cadet.Autograder.ResultStoreWorkerTest do
           end)
 
         assert answer.grade == result.grade
-        assert answer.adjustment == 0
 
         if answer.question.max_grade == 0 do
           assert answer.xp == 0

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -504,36 +504,6 @@ defmodule CadetWeb.GradingControllerTest do
     end
 
     @tag authenticate: :staff
-    test "invalid adjustment fails", %{conn: conn} do
-      %{answers: answers} = seed_db(conn)
-
-      answer = List.first(answers)
-
-      conn =
-        post(conn, build_url(answer.submission.id, answer.question.id), %{
-          "grading" => %{"adjustment" => -9_999_999_999}
-        })
-
-      assert response(conn, 400) ==
-               "adjustment must make total be between 0 and question.max_grade"
-    end
-
-    @tag authenticate: :staff
-    test "invalid xp_adjustment fails", %{conn: conn} do
-      %{answers: answers} = seed_db(conn)
-
-      answer = List.first(answers)
-
-      conn =
-        post(conn, build_url(answer.submission.id, answer.question.id), %{
-          "grading" => %{"xpAdjustment" => -9_999_999_999}
-        })
-
-      assert response(conn, 400) ==
-               "xp_adjustment must make total be between 0 and question.max_xp"
-    end
-
-    @tag authenticate: :staff
     test "staff who isn't the grader of said answer can still grade submission and grader field is updated correctly",
          %{conn: conn} do
       %{mentor: mentor, answers: answers} = seed_db(conn)


### PR DESCRIPTION
Fix #436 

the adjustment is calculated and updated such that the total grade/xp should be 0 <= total grade/xp <= max, hence preserving the previous validation.