### PR TITLE
Guided programming paths support

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -666,10 +666,15 @@ defmodule Cadet.Assessments do
       Answer
       |> where(submission_id: ^id)
       |> join(:inner, [a], q in assoc(a, :question))
+      |> join(:inner, [_, q], ast in assoc(q, :assessment))
       |> join(:left, [a, ...], g in assoc(a, :grader))
       |> join(:inner, [a, ...], s in assoc(a, :submission))
       |> join(:inner, [a, ..., s], st in assoc(s, :student))
-      |> preload([_, q, g, s, st], question: q, grader: g, submission: {s, student: st})
+      |> preload([_, q, ast, g, s, st],
+        question: {q, assessment: ast},
+        grader: g,
+        submission: {s, student: st}
+      )
 
     cond do
       role in @grading_roles ->

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -294,6 +294,7 @@ defmodule CadetWeb.AssessmentsController do
             answer(:string)
             score(:integer)
             program(:string)
+            type(:string, "One of public/hidden/private")
           end
         end,
       AutogradingResult:

--- a/lib/cadet_web/views/assessments_helpers.ex
+++ b/lib/cadet_web/views/assessments_helpers.ex
@@ -164,6 +164,14 @@ defmodule CadetWeb.AssessmentsHelpers do
     end
   end
 
+  defp build_postpend(%{assessment_type: assessment_type}) do
+    case assessment_type do
+      :path -> & &1["postpend"]
+      # Create a 1-arity function to return an empty postpend for non-paths
+      _ -> &Kernel.apply(fn _question -> "" end, [&1])
+    end
+  end
+
   defp build_question_content_by_type(%{
          question: %{question: question, type: question_type},
          assessment_type: assessment_type
@@ -174,7 +182,7 @@ defmodule CadetWeb.AssessmentsHelpers do
           content: "content",
           prepend: "prepend",
           solutionTemplate: "template",
-          postpend: "postpend",
+          postpend: build_postpend(%{assessment_type: assessment_type}),
           testcases: build_testcases(%{assessment_type: assessment_type})
         })
 

--- a/lib/cadet_web/views/grading_view.ex
+++ b/lib/cadet_web/views/grading_view.ex
@@ -51,8 +51,8 @@ defmodule CadetWeb.GradingView do
   defp build_grading_question(answer) do
     results = build_autograding_results(answer.autograding_results)
 
-    %{question: answer.question}
-    |> build_question()
+    %{question: answer.question, assessment_type: answer.question.assessment.type}
+    |> build_question_by_assessment_type()
     |> Map.put(:answer, answer.answer["code"] || answer.answer["choice_id"])
     |> Map.put(:autogradingStatus, answer.autograding_status)
     |> Map.put(:autogradingResults, results)

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -250,7 +250,12 @@ defmodule CadetWeb.AssessmentsControllerTest do
                 "content" => &1.question.content,
                 "solutionTemplate" => &1.question.template,
                 "prepend" => &1.question.prepend,
-                "postpend" => &1.question.postpend,
+                "postpend" =>
+                  if assessment.type == :path do
+                    &1.question.postpend
+                  else
+                    ""
+                  end,
                 "testcases" =>
                   Enum.map(
                     &1.question.public,

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -255,9 +255,23 @@ defmodule CadetWeb.AssessmentsControllerTest do
                   Enum.map(
                     &1.question.public,
                     fn testcase ->
-                      for {k, v} <- testcase, into: %{}, do: {Atom.to_string(k), v}
+                      for {k, v} <- testcase,
+                          into: %{"type" => "public"},
+                          do: {Atom.to_string(k), v}
                     end
-                  )
+                  ) ++
+                    if assessment.type == :path do
+                      Enum.map(
+                        &1.question.private,
+                        fn testcase ->
+                          for {k, v} <- testcase,
+                              into: %{"type" => "hidden"},
+                              do: {Atom.to_string(k), v}
+                        end
+                      )
+                    else
+                      []
+                    end
               }
             )
 

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -263,9 +263,23 @@ defmodule CadetWeb.GradingControllerTest do
                     Enum.map(
                       &1.question.question.public,
                       fn testcase ->
-                        for {k, v} <- testcase, into: %{}, do: {Atom.to_string(k), v}
+                        for {k, v} <- testcase,
+                            into: %{"type" => "public"},
+                            do: {Atom.to_string(k), v}
                       end
-                    ),
+                    ) ++
+                      if &1.question.assessment.type == :path do
+                        Enum.map(
+                          &1.question.question.private,
+                          fn testcase ->
+                            for {k, v} <- testcase,
+                                into: %{"type" => "hidden"},
+                                do: {Atom.to_string(k), v}
+                          end
+                        )
+                      else
+                        []
+                      end,
                   "solutionTemplate" => &1.question.question.template,
                   "type" => "#{&1.question.type}",
                   "id" => &1.question.id,
@@ -384,9 +398,23 @@ defmodule CadetWeb.GradingControllerTest do
                     Enum.map(
                       &1.question.question.public,
                       fn testcase ->
-                        for {k, v} <- testcase, into: %{}, do: {Atom.to_string(k), v}
+                        for {k, v} <- testcase,
+                            into: %{"type" => "public"},
+                            do: {Atom.to_string(k), v}
                       end
-                    ),
+                    ) ++
+                      if &1.question.assessment.type == :path do
+                        Enum.map(
+                          &1.question.question.private,
+                          fn testcase ->
+                            for {k, v} <- testcase,
+                                into: %{"type" => "hidden"},
+                                do: {Atom.to_string(k), v}
+                          end
+                        )
+                      else
+                        []
+                      end,
                   "solutionTemplate" => &1.question.question.template,
                   "type" => "#{&1.question.type}",
                   "id" => &1.question.id,
@@ -904,9 +932,23 @@ defmodule CadetWeb.GradingControllerTest do
                     Enum.map(
                       &1.question.question.public,
                       fn testcase ->
-                        for {k, v} <- testcase, into: %{}, do: {Atom.to_string(k), v}
+                        for {k, v} <- testcase,
+                            into: %{"type" => "public"},
+                            do: {Atom.to_string(k), v}
                       end
-                    ),
+                    ) ++
+                      if &1.question.assessment.type == :path do
+                        Enum.map(
+                          &1.question.question.private,
+                          fn testcase ->
+                            for {k, v} <- testcase,
+                                into: %{"type" => "hidden"},
+                                do: {Atom.to_string(k), v}
+                          end
+                        )
+                      else
+                        []
+                      end,
                   "solutionTemplate" => &1.question.question.template,
                   "type" => "#{&1.question.type}",
                   "id" => &1.question.id,

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -258,7 +258,12 @@ defmodule CadetWeb.GradingControllerTest do
               %{
                 "question" => %{
                   "prepend" => &1.question.question.prepend,
-                  "postpend" => &1.question.question.postpend,
+                  "postpend" =>
+                    if &1.question.assessment.type == :path do
+                      &1.question.question.postpend
+                    else
+                      ""
+                    end,
                   "testcases" =>
                     Enum.map(
                       &1.question.question.public,
@@ -393,7 +398,12 @@ defmodule CadetWeb.GradingControllerTest do
               %{
                 "question" => %{
                   "prepend" => &1.question.question.prepend,
-                  "postpend" => &1.question.question.postpend,
+                  "postpend" =>
+                    if &1.question.assessment.type == :path do
+                      &1.question.question.postpend
+                    else
+                      ""
+                    end,
                   "testcases" =>
                     Enum.map(
                       &1.question.question.public,
@@ -927,7 +937,12 @@ defmodule CadetWeb.GradingControllerTest do
               %{
                 "question" => %{
                   "prepend" => &1.question.question.prepend,
-                  "postpend" => &1.question.question.postpend,
+                  "postpend" =>
+                    if &1.question.assessment.type == :path do
+                      &1.question.question.postpend
+                    else
+                      ""
+                    end,
                   "testcases" =>
                     Enum.map(
                       &1.question.question.public,


### PR DESCRIPTION
## Guided programming paths support
Summary: Add backend support for guided programming paths. Provides some groundwork for addressing #445.

### Related PRs
Please review this PR in conjunction with this PR on cadet-frontend: https://github.com/source-academy/cadet-frontend/pull/833. Both PRs should be approved together. **This PR is complete.**

### Changelog
- Build new derived `type` attribute for every testcase rendered in `show.json` through the `/assessments/{assessmentId}` endpoint
- For Path assessments, in addition to public testcases, additionally render private testcases with type `hidden`
- Render the `postpend` of a programming question only for questions in Paths; programming questions in other assessments have their `postpend` set to the empty string `""` to prevent leaking grader programs

### Tests
- Update tests for assessment and grading controllers

Last updated 16 Aug 2019, 04:00AM