### PR TITLE
Build user with 'group' property for name of user's group

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -76,6 +76,12 @@ defmodule Cadet.Assessments do
     end
   end
 
+  def user_with_group(%User{id: id}) do
+    User
+    |> preload(:group)
+    |> Repo.get(id)
+  end
+
   def user_current_story(user = %User{}) do
     {:ok, %{result: story}} =
       Multi.new()

--- a/lib/cadet_web/controllers/user_controller.ex
+++ b/lib/cadet_web/controllers/user_controller.ex
@@ -9,7 +9,7 @@ defmodule CadetWeb.UserController do
   import Cadet.Assessments
 
   def index(conn, _) do
-    user = conn.assigns.current_user
+    user = user_with_group(conn.assigns.current_user)
     grade = user_total_grade(user)
     max_grade = user_max_grade(user)
     story = user_current_story(user)
@@ -29,7 +29,7 @@ defmodule CadetWeb.UserController do
   swagger_path :index do
     get("/user")
 
-    summary("Get the name and role of a user")
+    summary("Get the name, role and group of a user")
 
     security([%{JWT: []}])
 
@@ -55,23 +55,29 @@ defmodule CadetWeb.UserController do
               required: true
             )
 
+            group(
+              :string,
+              "Group the user belongs to. May be null if the user does not belong to any group.",
+              required: true
+            )
+
             story(Schema.ref(:UserStory), "Story to displayed to current user. ")
 
             grade(
               :integer,
-              "Amount of grade. Only provided for 'Student'." <>
+              "Amount of grade. Only provided for 'Student'. " <>
                 "Value will be 0 for non-students."
             )
 
             maxGrade(
               :integer,
-              "Total maximum grade achievable based on submitted assessments." <>
+              "Total maximum grade achievable based on submitted assessments. " <>
                 "Only provided for 'Student'"
             )
 
             xp(
               :integer,
-              "Amount of xp. Only provided for 'Student'." <> "Value will be 0 for non-students."
+              "Amount of xp. Only provided for 'Student'. " <> "Value will be 0 for non-students."
             )
           end
         end,

--- a/lib/cadet_web/views/user_view.ex
+++ b/lib/cadet_web/views/user_view.ex
@@ -5,6 +5,11 @@ defmodule CadetWeb.UserView do
     %{
       name: user.name,
       role: user.role,
+      group:
+        case user.group do
+          nil -> nil
+          _ -> user.group.name
+        end,
       grade: grade,
       xp: xp,
       maxGrade: max_grade,

--- a/test/cadet_web/controllers/user_controller_test.exs
+++ b/test/cadet_web/controllers/user_controller_test.exs
@@ -59,6 +59,7 @@ defmodule CadetWeb.UserControllerTest do
       expected = %{
         "name" => user.name,
         "role" => "#{user.role}",
+        "group" => nil,
         "xp" => 110,
         "grade" => 40,
         "maxGrade" => question.max_grade
@@ -210,6 +211,7 @@ defmodule CadetWeb.UserControllerTest do
       expected = %{
         "name" => user.name,
         "role" => "#{user.role}",
+        "group" => nil,
         "grade" => 0,
         "maxGrade" => 0,
         "xp" => 0


### PR DESCRIPTION
## Build user with 'group' property for name of user's group
Summary: Required to resolve https://github.com/source-academy/cadet-frontend/issues/753.

### Related PRs
Please review this PR in conjunction with this PR on cadet-frontend: https://github.com/source-academy/cadet-frontend/pull/946. Both PRs should be approved together. **This PR is complete.**

### Changelog
- Update the `/user` endpoint to retrieve and transmit the name of the user's group, to enable the front-end to conditionally render the unsubmit button using information about groups
   - `group` has type `:string`, but may be `:nil` (`null`) when a user belongs to no group

Last updated 24 Sept 2019, 01:30AM