### PR TITLE
increase luminus timeout

### DIFF
--- a/lib/cadet/accounts/luminus.ex
+++ b/lib/cadet/accounts/luminus.ex
@@ -212,8 +212,9 @@ defmodule Cadet.Accounts.Luminus do
   """
   def api_call(method, queries \\ [], token: token) do
     headers = [{"Ocp-Apim-Subscription-Key", @api_key}, {"Authorization", "Bearer #{token}"}]
+    options = [recv_timeout: 1000]
 
-    case HTTPoison.get(api_url(method, queries), headers) do
+    case HTTPoison.get(api_url(method, queries), headers, options) do
       {:ok, %{body: body, status_code: 200}} ->
         {:ok, Jason.decode!(body)}
 


### PR DESCRIPTION
Due to moving to luminus v3 ai #503, api calls are taking super long now.

This PR increases the default timeout of httppision from 5 sec to 10 sec!

To follow up with the luminus team!