### PR TITLE
Clarify phrasing on blank submissions

### DIFF
--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -146,7 +146,7 @@ defmodule Cadet.Autograder.GradingJob do
        when is_ecto_id(submission_id) do
     answer_content =
       case question_type do
-        :programming -> %{code: "// Question not answered by student."}
+        :programming -> %{code: "// Question was left blank by the student."}
         :mcq -> %{choice_id: 0}
       end
 

--- a/test/cadet/jobs/autograder/grading_job_test.exs
+++ b/test/cadet/jobs/autograder/grading_job_test.exs
@@ -249,7 +249,7 @@ defmodule Cadet.Autograder.GradingJobTest do
       for answer <- answers do
         assert answer.grade == 0
         assert answer.autograding_status == :success
-        assert answer.answer == %{"code" => "// Question not answered by student."}
+        assert answer.answer == %{"code" => "// Question was left blank by the student."}
         assert answer.room_id == nil
       end
 
@@ -313,7 +313,7 @@ defmodule Cadet.Autograder.GradingJobTest do
           assert answer.grade == 0
           assert answer.xp == 0
           assert answer.autograding_status == :success
-          assert answer.answer == %{"code" => "// Question not answered by student."}
+          assert answer.answer == %{"code" => "// Question was left blank by the student."}
           assert answer.room_id == nil
         end
       end


### PR DESCRIPTION
When a student submits a blank/empty submission, the backend adds the comment string
```
// Question not answered by student.
```
so that we can tell that the submission is blank/empty because the student had left it blank, rather than because of some error on our end.

Today, a student sent me a panicked email thinking that I had left the comment to accuse them of plagiarism (as in, the question was "not answered" by them, but by others). To avoid such misunderstandings, I propose the rephrasing
```
// Question was left blank by the student.
``` 

That's all this PR does.