### PR TITLE
CP3108 Staff Dashboard - Backend Modifications for Playground Default Source Version Selector

### DIFF
--- a/lib/cadet/chapters/chapter.ex
+++ b/lib/cadet/chapters/chapter.ex
@@ -1,19 +1,17 @@
 defmodule Cadet.Chapters.Chapter do
-    @moduledoc """
-    The Chapter entity the default chapter number.
-    """
-    use Cadet, :model
-    use Arc.Ecto.Schema
-  
-    alias Cadet.Chapters
-  
-    schema "chapters" do
-      field(:chapterno, :integer, default: :public)
-    end
-  
-    def changeset(chapter, params) do
-      chapter
-      |> cast(params, [:chapterno])
-    end
+  @moduledoc """
+  The Chapter entity for the default source version.
+  """
+  use Cadet, :model
+  use Arc.Ecto.Schema
+
+  schema "chapters" do
+    field(:chapterno, :integer, default: :public)
   end
-  
+
+  def changeset(chapter, params) do
+    chapter
+    |> cast(params, [:chapterno])
+    |> validate_inclusion(:chapterno, 1..4)
+  end
+end

--- a/lib/cadet/chapters/chapter.ex
+++ b/lib/cadet/chapters/chapter.ex
@@ -7,11 +7,15 @@ defmodule Cadet.Chapters.Chapter do
 
   schema "chapters" do
     field(:chapterno, :integer, default: :public)
+    field(:variant, :string, default: :public)
   end
+
+  @required_fields ~w(chapterno variant)a
 
   def changeset(chapter, params) do
     chapter
-    |> cast(params, [:chapterno])
+    |> cast(params, @required_fields)
     |> validate_inclusion(:chapterno, 1..4)
+    |> validate_inclusion(:variant, ["default", "wasm", "lazy", "concurrent", "non-det"])
   end
 end

--- a/lib/cadet/chapters/chapter.ex
+++ b/lib/cadet/chapters/chapter.ex
@@ -1,0 +1,19 @@
+defmodule Cadet.Chapters.Chapter do
+    @moduledoc """
+    The Chapter entity the default chapter number.
+    """
+    use Cadet, :model
+    use Arc.Ecto.Schema
+  
+    alias Cadet.Chapters
+  
+    schema "chapters" do
+      field(:chapterno, :integer, default: :public)
+    end
+  
+    def changeset(chapter, params) do
+      chapter
+      |> cast(params, [:chapterno])
+    end
+  end
+  

--- a/lib/cadet/chapters/chapters.ex
+++ b/lib/cadet/chapters/chapters.ex
@@ -4,14 +4,14 @@ defmodule Cadet.Chapters do
   """
   use Cadet, [:context, :display]
 
-  alias Cadet.Chapters.{Chapter}
+  alias Cadet.Chapters.Chapter
 
   import Ecto.Query
 
-  def get_chapter() do
-    # Chapters table should only have 1 entry (as seeded). 
+  def get_chapter do
+    # Chapters table should only have 1 entry (as seeded).
     # However, if table has more than 1 entry, the last created chapter entry will be returned.
-    chapter = from(chapter in Chapter, limit: 1, order_by: [desc: chapter.id]) |> Repo.one()
+    chapter = Chapter |> order_by(desc: :id) |> limit(1) |> Repo.one()
     {:ok, chapter}
   end
 

--- a/lib/cadet/chapters/chapters.ex
+++ b/lib/cadet/chapters/chapters.ex
@@ -1,21 +1,23 @@
 defmodule Cadet.Chapters do
-    @moduledoc """
-    Chapters context contains the default chapter number.
-    """
-    use Cadet, [:context, :display]
-  
-    alias Cadet.Chapters.{Chapter}
-  
-    def get_chapter() do
-      chapter = Repo.one(Chapter)
-      {:ok, chapter}
-    end
-  
-    def update_chapter(chapterno) do
-      chapter = Repo.one(Chapter)
-      changeset = Chapter.changeset(chapter, %{chapterno: chapterno})
-      Repo.update!(changeset)
-      {:ok, chapter}
-    end
+  @moduledoc """
+  Chapters context contains the default source version.
+  """
+  use Cadet, [:context, :display]
+
+  alias Cadet.Chapters.{Chapter}
+
+  import Ecto.Query
+
+  def get_chapter() do
+    # Chapters table should only have 1 entry (as seeded). However, if table has more than 1 entry, the last created chapter entry will be returned.
+    chapter = from(chapter in Chapter, limit: 1, order_by: [desc: chapter.id]) |> Repo.one()
+    {:ok, chapter}
   end
-  
+
+  def update_chapter(chapterno) do
+    {:ok, chapter} = get_chapter()
+    changeset = Chapter.changeset(chapter, %{chapterno: chapterno})
+    Repo.update!(changeset)
+    get_chapter()
+  end
+end

--- a/lib/cadet/chapters/chapters.ex
+++ b/lib/cadet/chapters/chapters.ex
@@ -1,0 +1,21 @@
+defmodule Cadet.Chapters do
+    @moduledoc """
+    Chapters context contains the default chapter number.
+    """
+    use Cadet, [:context, :display]
+  
+    alias Cadet.Chapters.{Chapter}
+  
+    def get_chapter() do
+      chapter = Repo.one(Chapter)
+      {:ok, chapter}
+    end
+  
+    def update_chapter(chapterno) do
+      chapter = Repo.one(Chapter)
+      changeset = Chapter.changeset(chapter, %{chapterno: chapterno})
+      Repo.update!(changeset)
+      {:ok, chapter}
+    end
+  end
+  

--- a/lib/cadet/chapters/chapters.ex
+++ b/lib/cadet/chapters/chapters.ex
@@ -9,14 +9,15 @@ defmodule Cadet.Chapters do
   import Ecto.Query
 
   def get_chapter() do
-    # Chapters table should only have 1 entry (as seeded). However, if table has more than 1 entry, the last created chapter entry will be returned.
+    # Chapters table should only have 1 entry (as seeded). 
+    # However, if table has more than 1 entry, the last created chapter entry will be returned.
     chapter = from(chapter in Chapter, limit: 1, order_by: [desc: chapter.id]) |> Repo.one()
     {:ok, chapter}
   end
 
-  def update_chapter(chapterno) do
+  def update_chapter(chapterno, variant) do
     {:ok, chapter} = get_chapter()
-    changeset = Chapter.changeset(chapter, %{chapterno: chapterno})
+    changeset = Chapter.changeset(chapter, %{chapterno: chapterno, variant: variant})
     Repo.update!(changeset)
     get_chapter()
   end

--- a/lib/cadet_web/controllers/chapters_controller.ex
+++ b/lib/cadet_web/controllers/chapters_controller.ex
@@ -1,0 +1,31 @@
+defmodule CadetWeb.ChaptersController do
+    @moduledoc """
+    Provides Chapter Number
+    """
+  
+    use CadetWeb, :controller
+    use PhoenixSwagger
+  
+    alias Cadet.Chapters
+  
+    def index(conn, _) do
+      {:ok, chapter} = Chapters.get_chapter()
+  
+      render(
+        conn,
+        "show.json",
+        chapter: chapter
+      )
+    end
+  
+    def update(conn, %{"id" => id, "chapterno" => chapterno}) do
+      {:ok, chapter} = Chapters.update_chapter(chapterno)
+  
+      render(
+        conn,
+        "show.json",
+        chapter: chapter
+      )
+    end
+  end
+  

--- a/lib/cadet_web/controllers/chapters_controller.ex
+++ b/lib/cadet_web/controllers/chapters_controller.ex
@@ -1,31 +1,30 @@
 defmodule CadetWeb.ChaptersController do
-    @moduledoc """
-    Provides Chapter Number
-    """
-  
-    use CadetWeb, :controller
-    use PhoenixSwagger
-  
-    alias Cadet.Chapters
-  
-    def index(conn, _) do
-      {:ok, chapter} = Chapters.get_chapter()
-  
-      render(
-        conn,
-        "show.json",
-        chapter: chapter
-      )
-    end
-  
-    def update(conn, %{"id" => id, "chapterno" => chapterno}) do
-      {:ok, chapter} = Chapters.update_chapter(chapterno)
-  
-      render(
-        conn,
-        "show.json",
-        chapter: chapter
-      )
-    end
+  @moduledoc """
+  Provides Chapter Number
+  """
+
+  use CadetWeb, :controller
+  use PhoenixSwagger
+
+  alias Cadet.Chapters
+
+  def index(conn, _) do
+    {:ok, chapter} = Chapters.get_chapter()
+
+    render(
+      conn,
+      "show.json",
+      chapter: chapter
+    )
   end
-  
+
+  def update(conn, %{"id" => _id, "chapterno" => chapterno}) do
+    {:ok, chapter} = Chapters.update_chapter(chapterno)
+
+    render(
+      conn,
+      "show.json",
+      chapter: chapter
+    )
+  end
+end

--- a/lib/cadet_web/controllers/chapters_controller.ex
+++ b/lib/cadet_web/controllers/chapters_controller.ex
@@ -18,8 +18,8 @@ defmodule CadetWeb.ChaptersController do
     )
   end
 
-  def update(conn, %{"id" => _id, "chapterno" => chapterno}) do
-    {:ok, chapter} = Chapters.update_chapter(chapterno)
+  def update(conn, %{"id" => _id, "chapterno" => chapterno, "variant" => variant}) do
+    {:ok, chapter} = Chapters.update_chapter(chapterno, variant)
 
     render(
       conn,

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -25,6 +25,7 @@ defmodule CadetWeb.Router do
     post("/auth", AuthController, :create)
     post("/auth/refresh", AuthController, :refresh)
     post("/auth/logout", AuthController, :logout)
+    get("/chapter", ChaptersController, :index)
   end
 
   # Authenticated Pages
@@ -35,8 +36,6 @@ defmodule CadetWeb.Router do
     resources("/material", MaterialController, only: [:create, :update, :delete])
 
     resources("/sourcecast", SourcecastController, only: [:create, :delete])
-
-    resources("/chapter", ChaptersController, only: [:index, :update])
 
     get("/assessments", AssessmentsController, :index)
     post("/assessments/:id", AssessmentsController, :show)

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -36,6 +36,8 @@ defmodule CadetWeb.Router do
 
     resources("/sourcecast", SourcecastController, only: [:create, :delete])
 
+    resources("/chapter", ChaptersController, only: [:index, :update])
+
     get("/assessments", AssessmentsController, :index)
     post("/assessments/:id", AssessmentsController, :show)
     post("/assessments/:assessmentid/submit", AssessmentsController, :submit)
@@ -55,6 +57,8 @@ defmodule CadetWeb.Router do
 
     post("/chat/token", ChatController, :index)
     post("/chat/notify", ChatController, :notify)
+
+    post("/chapter/update/:id", ChaptersController, :update)
   end
 
   # Other scopes may use custom stacks.

--- a/lib/cadet_web/views/chapters_view.ex
+++ b/lib/cadet_web/views/chapters_view.ex
@@ -1,0 +1,10 @@
+defmodule CadetWeb.ChaptersView do
+    use CadetWeb, :view
+  
+    def render("show.json", %{chapter: chapter}) do
+      %{
+        chapter: chapter
+      }
+    end
+  end
+  

--- a/lib/cadet_web/views/chapters_view.ex
+++ b/lib/cadet_web/views/chapters_view.ex
@@ -3,7 +3,11 @@ defmodule CadetWeb.ChaptersView do
 
   def render("show.json", %{chapter: chapter}) do
     %{
-      chapter: chapter
+      chapter:
+        transform_map_for_view(chapter, %{
+          chapterno: :chapterno,
+          variant: :variant
+        })
     }
   end
 end

--- a/lib/cadet_web/views/chapters_view.ex
+++ b/lib/cadet_web/views/chapters_view.ex
@@ -1,10 +1,9 @@
 defmodule CadetWeb.ChaptersView do
-    use CadetWeb, :view
-  
-    def render("show.json", %{chapter: chapter}) do
-      %{
-        chapter: chapter
-      }
-    end
+  use CadetWeb, :view
+
+  def render("show.json", %{chapter: chapter}) do
+    %{
+      chapter: chapter
+    }
   end
-  
+end

--- a/priv/repo/migrations/20200410124849_create_chapters.exs
+++ b/priv/repo/migrations/20200410124849_create_chapters.exs
@@ -1,10 +1,9 @@
-defmodule Cadet.Repo.Migrations.CreateChaptersTable do
+defmodule Cadet.Repo.Migrations.CreateChapters do
   use Ecto.Migration
 
   def change do
-    create table(:chapters) do 
+    create table(:chapters) do
       add(:chapterno, :integer, null: false)
     end
   end
 end
-

--- a/priv/repo/migrations/20200410124849_create_chapters_table.exs
+++ b/priv/repo/migrations/20200410124849_create_chapters_table.exs
@@ -1,0 +1,10 @@
+defmodule Cadet.Repo.Migrations.CreateChaptersTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:chapters) do 
+      add(:chapterno, :integer, null: false)
+    end
+  end
+end
+

--- a/priv/repo/migrations/20200423155735_add_variant_to_chapters.exs
+++ b/priv/repo/migrations/20200423155735_add_variant_to_chapters.exs
@@ -1,0 +1,9 @@
+defmodule Cadet.Repo.Migrations.AddVariantToChapters do
+  use Ecto.Migration
+
+  def change do
+    alter table(:chapters) do
+      add(:variant, :string, null: false)
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,7 +11,7 @@
 # and so on) as they will fail if something goes wrong.
 import Cadet.Factory
 alias Cadet.Assessments.SubmissionStatus
- 
+
 # insert default chapter
 Cadet.Repo.insert!(%Cadet.Chapters.Chapter{chapterno: 1})
 
@@ -23,8 +23,6 @@ if Application.get_env(:cadet, :environment) == :dev do
   students = insert_list(5, :student, %{group: group})
   admin = insert(:user, %{name: "admin", role: :admin})
   Enum.each([avenger, mentor] ++ students, &insert(:nusnet_id, %{user: &1}))
-
-  # // Cadet.Repo.insert!(%Cadet.SomeSchema{})
 
   # Assessments
   for _ <- 1..5 do
@@ -104,5 +102,4 @@ if Application.get_env(:cadet, :environment) == :dev do
       })
     end
   end
-
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,8 +12,8 @@
 import Cadet.Factory
 alias Cadet.Assessments.SubmissionStatus
 
-# insert default chapter
-Cadet.Repo.insert!(%Cadet.Chapters.Chapter{chapterno: 1})
+# insert default source version
+Cadet.Repo.insert!(%Cadet.Chapters.Chapter{chapterno: 1, variant: "default"})
 
 if Application.get_env(:cadet, :environment) == :dev do
   # User and Group

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,6 +11,9 @@
 # and so on) as they will fail if something goes wrong.
 import Cadet.Factory
 alias Cadet.Assessments.SubmissionStatus
+ 
+# insert default chapter
+Cadet.Repo.insert!(%Cadet.Chapters.Chapter{chapterno: 1})
 
 if Application.get_env(:cadet, :environment) == :dev do
   # User and Group
@@ -20,6 +23,8 @@ if Application.get_env(:cadet, :environment) == :dev do
   students = insert_list(5, :student, %{group: group})
   admin = insert(:user, %{name: "admin", role: :admin})
   Enum.each([avenger, mentor] ++ students, &insert(:nusnet_id, %{user: &1}))
+
+  # // Cadet.Repo.insert!(%Cadet.SomeSchema{})
 
   # Assessments
   for _ <- 1..5 do
@@ -99,4 +104,5 @@ if Application.get_env(:cadet, :environment) == :dev do
       })
     end
   end
+
 end

--- a/test/cadet/chapters/chapter_test.exs
+++ b/test/cadet/chapters/chapter_test.exs
@@ -7,16 +7,28 @@ defmodule Cadet.Chapters.ChapterTest do
     test "valid changeset" do
       assert_changeset(
         %{
-          chapterno: Enum.random(1..4)
+          chapterno: 1,
+          variant: "default"
         },
         :valid
       )
     end
 
-    test "invalid changeset" do
+    test "invalid changeset for chapterno" do
       assert_changeset(
         %{
-          chapterno: 5
+          chapterno: 5,
+          variant: "default"
+        },
+        :invalid
+      )
+    end
+
+    test "invalid changeset for variant" do
+      assert_changeset(
+        %{
+          chapterno: 1,
+          variant: "wrong variant"
         },
         :invalid
       )

--- a/test/cadet/chapters/chapter_test.exs
+++ b/test/cadet/chapters/chapter_test.exs
@@ -1,0 +1,25 @@
+defmodule Cadet.Chapters.ChapterTest do
+  alias Cadet.Chapters.Chapter
+
+  use Cadet.ChangesetCase, entity: Chapter
+
+  describe "Changesets" do
+    test "valid changeset" do
+      assert_changeset(
+        %{
+          chapterno: Enum.random(1..4)
+        },
+        :valid
+      )
+    end
+
+    test "invalid changeset" do
+      assert_changeset(
+        %{
+          chapterno: 5
+        },
+        :invalid
+      )
+    end
+  end
+end

--- a/test/cadet/chapters/chapters_test.exs
+++ b/test/cadet/chapters/chapters_test.exs
@@ -7,12 +7,14 @@ defmodule Cadet.ChaptersTest do
     insert(:chapter)
     {:ok, chapter} = Chapters.get_chapter()
     assert chapter.chapterno == 1
+    assert chapter.variant == "default"
   end
 
   test "update chapter" do
     insert(:chapter)
     no = Enum.random(1..4)
-    {:ok, chapter} = Chapters.update_chapter(no)
+    {:ok, chapter} = Chapters.update_chapter(no, "default")
     assert chapter.chapterno == no
+    assert chapter.variant == "default"
   end
 end

--- a/test/cadet/chapters/chapters_test.exs
+++ b/test/cadet/chapters/chapters_test.exs
@@ -1,0 +1,18 @@
+defmodule Cadet.ChaptersTest do
+  use Cadet.DataCase
+
+  alias Cadet.Chapters
+
+  test "get chapter" do
+    insert(:chapter)
+    {:ok, chapter} = Chapters.get_chapter()
+    assert chapter.chapterno == 1
+  end
+
+  test "update chapter" do
+    insert(:chapter)
+    no = Enum.random(1..4)
+    {:ok, chapter} = Chapters.update_chapter(no)
+    assert chapter.chapterno == no
+  end
+end

--- a/test/cadet_web/controllers/chapters_controller_test.exs
+++ b/test/cadet_web/controllers/chapters_controller_test.exs
@@ -1,0 +1,46 @@
+defmodule CadetWeb.ChaptersControllerTest do
+  use CadetWeb.ConnCase
+
+  describe "GET /chapter" do
+    @tag authenticate: :staff
+    test "successful", %{conn: conn} do
+      insert(:chapter)
+
+      resp =
+        conn
+        |> get(build_url())
+        |> json_response(200)
+
+      with %{"chapter" => %{"chapterno" => chapterno}} <- resp do
+        assert chapterno == 1
+      else
+        _ -> assert false
+      end
+    end
+  end
+
+  describe "POST /chapter/update/:id" do
+    @tag authenticate: :staff
+    test "successful", %{conn: conn} do
+      insert(:chapter)
+
+      no = Enum.random(1..4)
+
+      resp =
+        conn
+        |> post(build_url(1), %{
+          "chapterno" => no
+        })
+        |> json_response(200)
+
+      with %{"chapter" => %{"chapterno" => chapterno}} <- resp do
+        assert chapterno == no
+      else
+        _ -> assert false
+      end
+    end
+  end
+
+  defp build_url, do: "/v1/chapter/"
+  defp build_url(chapter_id), do: "#{build_url()}update/#{chapter_id}/"
+end

--- a/test/cadet_web/controllers/chapters_controller_test.exs
+++ b/test/cadet_web/controllers/chapters_controller_test.exs
@@ -11,12 +11,9 @@ defmodule CadetWeb.ChaptersControllerTest do
         |> get(build_url())
         |> json_response(200)
 
-      with %{"chapter" => %{"chapterno" => chapterno, "variant" => variant}} <- resp do
-        assert chapterno == 1
-        assert variant == "default"
-      else
-        _ -> assert false
-      end
+      %{"chapter" => %{"chapterno" => chapterno, "variant" => variant}} = resp
+      assert chapterno == 1
+      assert variant == "default"
     end
   end
 
@@ -35,12 +32,9 @@ defmodule CadetWeb.ChaptersControllerTest do
         })
         |> json_response(200)
 
-      with %{"chapter" => %{"chapterno" => chapterno, "variant" => variant}} <- resp do
-        assert chapterno == no
-        assert variant == "default"
-      else
-        _ -> assert false
-      end
+      %{"chapter" => %{"chapterno" => chapterno, "variant" => variant}} = resp
+      assert chapterno == no
+      assert variant == "default"
     end
   end
 

--- a/test/cadet_web/controllers/chapters_controller_test.exs
+++ b/test/cadet_web/controllers/chapters_controller_test.exs
@@ -11,8 +11,9 @@ defmodule CadetWeb.ChaptersControllerTest do
         |> get(build_url())
         |> json_response(200)
 
-      with %{"chapter" => %{"chapterno" => chapterno}} <- resp do
+      with %{"chapter" => %{"chapterno" => chapterno, "variant" => variant}} <- resp do
         assert chapterno == 1
+        assert variant == "default"
       else
         _ -> assert false
       end
@@ -29,12 +30,14 @@ defmodule CadetWeb.ChaptersControllerTest do
       resp =
         conn
         |> post(build_url(1), %{
-          "chapterno" => no
+          "chapterno" => no,
+          "variant" => "default"
         })
         |> json_response(200)
 
-      with %{"chapter" => %{"chapterno" => chapterno}} <- resp do
+      with %{"chapter" => %{"chapterno" => chapterno, "variant" => variant}} <- resp do
         assert chapterno == no
+        assert variant == "default"
       else
         _ -> assert false
       end

--- a/test/factories/chapters/chapter_factory.ex
+++ b/test/factories/chapters/chapter_factory.ex
@@ -1,0 +1,17 @@
+defmodule Cadet.Chapters.ChapterFactory do
+  @moduledoc """
+  Factory for Chapter entity
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Cadet.Chapters.Chapter
+
+      def chapter_factory do
+        %Chapter{
+          chapterno: 1
+        }
+      end
+    end
+  end
+end

--- a/test/factories/chapters/chapter_factory.ex
+++ b/test/factories/chapters/chapter_factory.ex
@@ -9,7 +9,8 @@ defmodule Cadet.Chapters.ChapterFactory do
 
       def chapter_factory do
         %Chapter{
-          chapterno: 1
+          chapterno: 1,
+          variant: "default"
         }
       end
     end

--- a/test/factories/factory.ex
+++ b/test/factories/factory.ex
@@ -14,6 +14,8 @@ defmodule Cadet.Factory do
     SubmissionFactory
   }
 
+  use Cadet.Chapters.{ChapterFactory}
+
   use Cadet.Course.{GroupFactory, MaterialFactory, SourcecastFactory}
 
   def upload_factory do


### PR DESCRIPTION
### **Context**
This PR is for modifying the backend API to support the Playground Default Source Version Selector for the CP3018 Staff Dashboard project.

The Playground Default Source Version Selector is meant to allow staff to easily change the default source version for the playground.

### **Implementation**
Added a new table, 'Chapter'. The table contains a single entry with the current default source version. Added GET and UPDATE routes.

### **Other Information**
Corresponding PR to cadet: https://github.com/source-academy/cadet-frontend/pull/1073