### PR TITLE
CP3108 Staff Dashboard - Backend Modifications for Assessment Uploader

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -393,16 +393,13 @@ defmodule Cadet.Assessments do
             |> Repo.insert()
           else
             params =
-              if !question_params.max_xp do
-                question_params
-                |> Map.put(:max_xp, 0)
-              else
-                question_params
-              end
+              question_params
+              |> Map.put_new(:max_xp, 0)
               |> Map.put(:display_order, index)
 
             %{id: question_id, type: type} =
-              where(Question, [q], q.display_order == ^index and q.assessment_id == ^id)
+              Question
+              |> where([q], q.display_order == ^index and q.assessment_id == ^id)
               |> Repo.one()
 
             if question_params.type != Atom.to_string(type) do
@@ -433,23 +430,23 @@ defmodule Cadet.Assessments do
        |> elem(1)
        |> elem(1)).data.id
 
-    # check if assessment already exists
-    if !assessment_id do
-      false
-    else
+    if assessment_id do
       open_date = Repo.get(Assessment, assessment_id).open_at
       # check if assessment is already opened
       if Timex.after?(open_date, Timex.now()) do
         false
       else
         existing_questions_count =
-          where(Question, [q], q.assessment_id == ^assessment_id)
+          Question
+          |> where([q], q.assessment_id == ^assessment_id)
           |> Repo.all()
           |> Enum.count()
 
         new_questions_count = Enum.count(questions_params)
         existing_questions_count != new_questions_count
       end
+    else
+      false
     end
   end
 

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -7,7 +7,7 @@ defmodule Cadet.Assessments do
 
   import Ecto.Query
 
-  alias Cadet.Accounts.{Notifications, User}
+  alias Cadet.Accounts.{Notification, Notifications, User}
   alias Cadet.Assessments.{Answer, Assessment, Query, Question, Submission}
   alias Cadet.Autograder.GradingJob
   alias Cadet.Chat.Room
@@ -64,13 +64,30 @@ defmodule Cadet.Assessments do
 
       Submission
       |> where(assessment_id: ^id)
-      |> Repo.delete_all()
+      |> delete_submission_assocation(id)
 
       Repo.delete(assessment)
     else
       {:error, {:forbidden, "User is not permitted to delete"}}
     end
   end
+
+  defp delete_submission_assocation(submissions, assessment_id) do
+    submissions
+    |> Repo.all()
+    |> Enum.each(fn submission ->
+      Answer
+      |> where(submission_id: ^submission.id)
+      |> Repo.delete_all()
+    end)
+
+    Notification
+    |> where(assessment_id: ^assessment_id)
+    |> Repo.delete_all()
+
+    Repo.delete_all(submissions)
+  end
+
 
   @spec user_total_xp(%User{}) :: integer()
   def user_total_xp(%User{id: user_id}) when is_ecto_id(user_id) do

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -42,7 +42,7 @@ defmodule Cadet.Assessments do
           {:error, {:bad_request, "New Opening date should occur after current time"}}
 
         true ->
-          {:error, {:forbidden, "Assessment is already opened"}}
+          {:error, {:unauthorized, "Assessment is already opened"}}
       end
     else
       {:error, {:forbidden, "User is not permitted to edit"}}

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -61,6 +61,11 @@ defmodule Cadet.Assessments do
   def delete_assessment(_deleter = %User{role: role}, id) do
     if role in @delete_assessment_role do
       assessment = Repo.get(Assessment, id)
+
+      Submission
+      |> where(assessment_id: ^id)
+      |> Repo.delete_all()
+
       Repo.delete(assessment)
     else
       {:error, {:forbidden, "User is not permitted to delete"}}

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -28,6 +28,7 @@ defmodule Cadet.Assessments do
     if role in @change_dates_assessment_role do
       assessment = Repo.get(Assessment, id)
       previous_open_time = assessment.open_at
+
       cond do
         Timex.before?(close_at, open_at) ->
           {:error, {:bad_request, "New end date should occur after new opening date"}}
@@ -215,6 +216,7 @@ defmodule Cadet.Assessments do
   def assessment_with_questions_and_answers(id, user = %User{}, password)
       when is_ecto_id(id) do
     role = user.role
+
     assessment =
       if role in @open_all_assessment_roles do
         Assessment
@@ -319,6 +321,7 @@ defmodule Cadet.Assessments do
 
   def filter_published_assessments(assessments, user) do
     role = user.role
+
     case role do
       :student -> where(assessments, is_published: true)
       _ -> assessments
@@ -352,7 +355,11 @@ defmodule Cadet.Assessments do
   @spec insert_or_update_assessments_and_questions(map(), [map()], boolean()) ::
           {:ok, any()}
           | {:error, Ecto.Multi.name(), any(), %{optional(Ecto.Multi.name()) => any()}}
-  def insert_or_update_assessments_and_questions(assessment_params, questions_params, force_update) do
+  def insert_or_update_assessments_and_questions(
+        assessment_params,
+        questions_params,
+        force_update
+      ) do
     assessment_multi =
       Multi.insert_or_update(
         Multi.new(),
@@ -369,7 +376,10 @@ defmodule Cadet.Assessments do
         Multi.run(multi, String.to_atom("question#{index}"), fn _repo,
                                                                 %{assessment: %Assessment{id: id}} ->
           question_exists =
-            Repo.exists?(where(Question, [q], q.assessment_id == ^id and q.display_order == ^index))
+            Repo.exists?(
+              where(Question, [q], q.assessment_id == ^id and q.display_order == ^index)
+            )
+
           # the !question_exists check allows for force updating of brand new assessments
           if !force_update or !question_exists do
             question_params
@@ -378,12 +388,12 @@ defmodule Cadet.Assessments do
             |> Repo.insert()
           else
             params =
-              (if !question_params.max_xp do
+              if !question_params.max_xp do
                 question_params
                 |> Map.put(:max_xp, 0)
               else
                 question_params
-              end)
+              end
               |> Map.put(:display_order, index)
 
             %{id: question_id, type: type} =
@@ -391,9 +401,15 @@ defmodule Cadet.Assessments do
               |> Repo.one()
 
             if question_params.type != Atom.to_string(type) do
-              {:error, create_invalid_changeset_with_error(:question, "Question types should remain the same")}
+              {:error,
+               create_invalid_changeset_with_error(
+                 :question,
+                 "Question types should remain the same"
+               )}
             else
-              changeset = Question.changeset(%Question{assessment_id: id, id: question_id}, params)
+              changeset =
+                Question.changeset(%Question{assessment_id: id, id: question_id}, params)
+
               Repo.update(changeset)
             end
           end
@@ -408,9 +424,9 @@ defmodule Cadet.Assessments do
   defp invalid_force_update(assessment_multi, questions_params) do
     assessment_id =
       (assessment_multi.operations
-      |> List.first()
-      |> elem(1)
-      |> elem(1)).data.id
+       |> List.first()
+       |> elem(1)
+       |> elem(1)).data.id
 
     # check if assessment already exists
     if !assessment_id do
@@ -424,7 +440,8 @@ defmodule Cadet.Assessments do
         existing_questions_count =
           where(Question, [q], q.assessment_id == ^assessment_id)
           |> Repo.all()
-          |> Enum.count
+          |> Enum.count()
+
         new_questions_count = Enum.count(questions_params)
         existing_questions_count != new_questions_count
       end
@@ -439,6 +456,7 @@ defmodule Cadet.Assessments do
     |> case do
       nil ->
         Assessment.changeset(%Assessment{}, params)
+
       assessment ->
         cond do
           Timex.after?(assessment.open_at, Timex.now()) ->

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -33,12 +33,6 @@ defmodule Cadet.Assessments do
         Timex.before?(close_at, open_at) ->
           {:error, {:bad_request, "New end date should occur after new opening date"}}
 
-        Timex.before?(close_at, Timex.now()) ->
-          {:error, {:bad_request, "New end date should occur after current time"}}
-
-        Timex.before?(open_at, Timex.now()) ->
-          {:error, {:bad_request, "New Opening date should occur after current time"}}
-
         Timex.equal?(previous_open_time, open_at) or Timex.after?(previous_open_time, Timex.now()) ->
           update_assessment(id, %{close_at: close_at, open_at: open_at})
 

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -16,10 +16,55 @@ defmodule Cadet.Assessments do
   @xp_early_submission_max_bonus 100
   @xp_bonus_assessment_type ~w(mission sidequest)a
   @submit_answer_roles ~w(student)a
+  @change_dates_assessment_role ~w(staff admin)a
+  @delete_assessment_role ~w(staff admin)a
+  @publish_assessment_role ~w(staff admin)a
   @unsubmit_assessment_role ~w(staff admin)a
   @grading_roles ~w()a
   @see_all_submissions_roles ~w(staff admin)a
   @open_all_assessment_roles ~w(staff admin)a
+
+  def change_dates_assessment(_user = %User{role: role}, id, close_at, open_at) do
+    if role in @change_dates_assessment_role do
+      assessment = Repo.get(Assessment, id)
+      previous_open_time = assessment.open_at
+      cond do
+        Timex.before?(close_at, open_at) -> 
+          {:error, {:bad_request, "New end date should occur after new opening date"}}
+
+        Timex.before?(close_at, Timex.now()) ->
+          {:error, {:bad_request, "New end date should occur after current time"}}
+
+        Timex.equal?(previous_open_time, open_at) or Timex.after?(previous_open_time, Timex.now()) ->
+          update_assessment(id, %{close_at: close_at, open_at: open_at})
+
+        Timex.before?(open_at, Timex.now()) ->
+          {:error, {:bad_request, "New Opening date should occur after current time"}}
+        
+        true ->
+          {:error, {:forbidden, "Assessment is already opened"}}
+      end
+    else
+      {:error, {:forbidden, "User is not permitted to edit"}}
+    end
+  end
+
+  def toggle_publish_assessment(_publisher = %User{role: role}, id, bool) do
+    if role in @publish_assessment_role do
+      update_assessment(id, %{is_published: bool})
+    else
+      {:error, {:forbidden, "User is not permitted to publish"}}
+    end
+  end
+
+  def delete_assessment(_deleter = %User{role: role}, id) do
+    if role in @delete_assessment_role do
+      assessment = Repo.get(Assessment, id)
+      Repo.delete(assessment)
+    else
+      {:error, {:forbidden, "User is not permitted to delete"}}
+    end
+  end
 
   @spec user_total_xp(%User{}) :: integer()
   def user_total_xp(%User{id: user_id}) when is_ecto_id(user_id) do
@@ -169,11 +214,18 @@ defmodule Cadet.Assessments do
 
   def assessment_with_questions_and_answers(id, user = %User{}, password)
       when is_ecto_id(id) do
+    role = user.role
     assessment =
-      Assessment
-      |> where(id: ^id)
-      |> where(is_published: true)
-      |> Repo.one()
+      if role in @open_all_assessment_roles do
+        Assessment
+        |> where(id: ^id)
+        |> Repo.one()
+      else
+        Assessment
+        |> where(id: ^id)
+        |> where(is_published: true)
+        |> Repo.one()
+      end
 
     if assessment do
       assessment_with_questions_and_answers(assessment, user, password)
@@ -212,11 +264,7 @@ defmodule Cadet.Assessments do
     assessment_with_questions_and_answers(id, user, nil)
   end
 
-  @doc """
-  Returns a list of assessments with all fields and an indicator showing whether it has been attempted
-  by the supplied user
-  """
-  def all_published_assessments(user = %User{}) do
+  def all_assessments(user = %User{}) do
     assessments =
       Query.all_assessments_with_max_xp_and_grade()
       |> subquery()
@@ -246,7 +294,7 @@ defmodule Cadet.Assessments do
           question_count: q_count.count,
           graded_count: a_count.count
       })
-      |> where(is_published: true)
+      |> filter_published_assessments(user)
       |> order_by(:open_at)
       |> Repo.all()
       |> Enum.map(fn assessment = %Assessment{} ->
@@ -263,6 +311,14 @@ defmodule Cadet.Assessments do
       end)
 
     {:ok, assessments}
+  end
+
+  def filter_published_assessments(assessments, user) do 
+    role = user.role
+    case role do
+      :student -> where(assessments, is_published: true)
+      _ -> assessments
+    end
   end
 
   defp build_grading_status(submission_status, a_type, q_count, g_count) do
@@ -289,53 +345,108 @@ defmodule Cadet.Assessments do
   @doc """
   The main function that inserts or updates assessments from the XML Parser
   """
-  @spec insert_or_update_assessments_and_questions(map(), [map()]) ::
+  @spec insert_or_update_assessments_and_questions(map(), [map()], boolean()) ::
           {:ok, any()}
           | {:error, Ecto.Multi.name(), any(), %{optional(Ecto.Multi.name()) => any()}}
-  def insert_or_update_assessments_and_questions(assessment_params, questions_params) do
+  def insert_or_update_assessments_and_questions(assessment_params, questions_params, force_update) do
     assessment_multi =
       Multi.insert_or_update(
         Multi.new(),
         :assessment,
-        insert_or_update_assessment_changeset(assessment_params)
+        insert_or_update_assessment_changeset(assessment_params, force_update)
       )
 
-    questions_params
-    |> Enum.with_index(1)
-    |> Enum.reduce(assessment_multi, fn {question_params, index}, multi ->
-      Multi.run(multi, String.to_atom("question#{index}"), fn _repo,
-                                                              %{assessment: %Assessment{id: id}} ->
-        question_params
-        |> Map.put(:display_order, index)
-        |> build_question_changeset_for_assessment_id(id)
-        |> Repo.insert()
+    if force_update and check_question_count(assessment_multi, questions_params) do
+      {:error, "Question count is different"}
+    else
+      questions_params
+      |> Enum.with_index(1)
+      |> Enum.reduce(assessment_multi, fn {question_params, index}, multi ->
+        Multi.run(multi, String.to_atom("question#{index}"), fn _repo,
+                                                                %{assessment: %Assessment{id: id}} ->
+          question_exists = 
+            Repo.exists?(where(Question, [q], q.assessment_id == ^id and q.display_order == ^index))
+          if !force_update or !question_exists do 
+            question_params
+            |> Map.put(:display_order, index)
+            |> build_question_changeset_for_assessment_id(id)
+            |> Repo.insert()
+          else
+            params = 
+              (if !question_params.max_xp do 
+                question_params
+                |> Map.put(:max_xp, 0)
+              else
+                question_params
+              end)
+              |> Map.put(:display_order, index)
+
+            %{id: question_id} = 
+              where(Question, [q], q.display_order == ^index and q.assessment_id == ^id)
+              |> Repo.one()
+
+            changeset = Question.changeset(%Question{assessment_id: id, id: question_id}, params)
+            Repo.update(changeset)
+          end
+        end)
       end)
-    end)
-    |> Repo.transaction()
+      |> Repo.transaction()
+    end
   end
 
-  @spec insert_or_update_assessment_changeset(map()) :: Ecto.Changeset.t()
-  defp insert_or_update_assessment_changeset(params = %{number: number}) do
+  defp check_question_count(assessment_multi, questions_params) do
+    assessment_id =
+      (assessment_multi.operations
+      |> List.first()
+      |> elem(1)
+      |> elem(1)).data.id
+
+    if !assessment_id do 
+      false 
+    else
+      existing_questions_count = 
+      where(Question, [q], q.assessment_id == ^assessment_id)
+      |> Repo.all()
+      |> Enum.count
+
+      new_questions_count = Enum.count(questions_params)
+
+      existing_questions_count != new_questions_count
+    end    
+  end
+
+  @spec insert_or_update_assessment_changeset(map(), boolean()) :: Ecto.Changeset.t()
+  defp insert_or_update_assessment_changeset(params = %{number: number}, force_update) do
     Assessment
     |> where(number: ^number)
     |> Repo.one()
     |> case do
       nil ->
         Assessment.changeset(%Assessment{}, params)
-
       assessment ->
-        if Timex.after?(assessment.open_at, Timex.now()) do
-          # Delete all existing questions
-          %{id: assessment_id} = assessment
+        cond do
+          Timex.after?(assessment.open_at, Timex.now()) ->
+            # Delete all existing questions
+            %{id: assessment_id} = assessment
 
-          Question
-          |> where(assessment_id: ^assessment_id)
-          |> Repo.delete_all()
+            Question
+            |> where(assessment_id: ^assessment_id)
+            |> Repo.delete_all()
 
-          Assessment.changeset(assessment, params)
-        else
-          # if the assessment is already open, don't mess with it
-          create_invalid_changeset_with_error(:assessment, "is already open")
+            Assessment.changeset(assessment, params)
+
+          force_update ->
+            # Maintain the same open/close date when force updating an assessment
+            new_params = 
+              params
+              |> Map.delete(:open_at)
+              |> Map.delete(:close_at)
+
+            Assessment.changeset(assessment, new_params)
+
+          true ->
+            # if the assessment is already open, don't mess with it
+            create_invalid_changeset_with_error(:assessment, "is already open")
         end
     end
   end

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -264,6 +264,10 @@ defmodule Cadet.Assessments do
     assessment_with_questions_and_answers(id, user, nil)
   end
 
+  @doc """
+  Returns a list of assessments with all fields and an indicator showing whether it has been attempted
+  by the supplied user
+  """
   def all_assessments(user = %User{}) do
     assessments =
       Query.all_assessments_with_max_xp_and_grade()

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -36,11 +36,11 @@ defmodule Cadet.Assessments do
         Timex.before?(close_at, Timex.now()) ->
           {:error, {:bad_request, "New end date should occur after current time"}}
 
-        Timex.equal?(previous_open_time, open_at) or Timex.after?(previous_open_time, Timex.now()) ->
-          update_assessment(id, %{close_at: close_at, open_at: open_at})
-
         Timex.before?(open_at, Timex.now()) ->
           {:error, {:bad_request, "New Opening date should occur after current time"}}
+
+        Timex.equal?(previous_open_time, open_at) or Timex.after?(previous_open_time, Timex.now()) ->
+          update_assessment(id, %{close_at: close_at, open_at: open_at})
 
         true ->
           {:error, {:unauthorized, "Assessment is already opened"}}

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -50,9 +50,10 @@ defmodule Cadet.Assessments do
     end
   end
 
-  def toggle_publish_assessment(_publisher = %User{role: role}, id, toggle_publish_to) do
+  def toggle_publish_assessment(_publisher = %User{role: role}, id) do
     if role in @publish_assessment_role do
-      update_assessment(id, %{is_published: toggle_publish_to})
+      assessment = Repo.get(Assessment, id)
+      update_assessment(id, %{is_published: !assessment.is_published})
     else
       {:error, {:forbidden, "User is not permitted to publish"}}
     end

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -88,7 +88,6 @@ defmodule Cadet.Assessments do
     Repo.delete_all(submissions)
   end
 
-
   @spec user_total_xp(%User{}) :: integer()
   def user_total_xp(%User{id: user_id}) when is_ecto_id(user_id) do
     total_xp_bonus =

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -102,33 +102,33 @@ defmodule Cadet.Updater.XMLParser do
 
       {:error, stage, changeset, _} when is_atom(stage) ->
         log_error_bad_changeset(changeset, stage)
-        changeset_error = 
+        changeset_error =
           changeset
           |> Map.get(:errors)
           |> extract_changeset_error_message
-        error_message = "Invalid #{stage} changeset " <> changeset_error
+        error_message = "Invalid #{stage} changeset #{changeset_error}"
         log_and_return_badrequest(error_message)
     end
   catch
     # the :erlsom library used by SweetXml will exit if XML is invalid
     :exit, parse_error ->
-      error_message = 
+      error_message =
         parse_error
         |> nested_tuple_to_list()
         |> List.flatten()
-        |> Enum.reduce("", fn x, acc -> acc <> to_string(x) <> " " end)
-      {:error, {:bad_request, "Invalid XML " <> error_message}}
+        |> Enum.reduce("", fn x, acc -> "#{acc <> to_string(x)} " end)
+      {:error, {:bad_request, "Invalid XML #{error_message}"}}
   end
 
   defp extract_changeset_error_message(errors_list) do
     errors_list
-    |> Enum.map(fn {field, {error, _}} -> to_string(field) <> " " <> error end)
-    |> List.foldr("", fn x, acc -> acc <> x <> " " end)
+    |> Enum.map(fn {field, {error, _}} -> "#{to_string(field)} #{error}" end)
+    |> List.foldr("", fn x, acc -> "#{acc <> x} " end)
   end
 
   @spec process_assessment(String.t()) :: {:ok, map()} | {:error, String.t}
   defp process_assessment(xml) do
-    open_at = 
+    open_at =
       Timex.now()
       |> Timex.beginning_of_day()
       |> Timex.shift(days: 3)
@@ -164,7 +164,7 @@ defmodule Cadet.Updater.XMLParser do
     end
 
     {:ok, assessment_params}
-    
+
   rescue
     # This error is raised by xpath/3 when TASK does not exist (hence is equal to nil)
     Protocol.UndefinedError ->
@@ -213,7 +213,7 @@ defmodule Cadet.Updater.XMLParser do
         else
           {:no_missing_attr?, false} ->
             {:error, "Missing attribute(s) on PROBLEM"}
-          
+
           {:error, errmsg} ->
             {:error, errmsg}
         end

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -77,7 +77,8 @@ defmodule Cadet.Updater.XMLParser do
     end
   end
 
-  @spec parse_xml(String.t(), boolean()) :: :ok | {:ok, String.t} | {:error, {atom(), String.t}}
+  @spec parse_xml(String.t(), boolean()) ::
+          :ok | {:ok, String.t()} | {:error, {atom(), String.t()}}
   def parse_xml(xml, force_update \\ false) do
     with {:ok, assessment_params} <- process_assessment(xml),
          {:ok, questions_params} <- process_questions(xml),
@@ -102,10 +103,12 @@ defmodule Cadet.Updater.XMLParser do
 
       {:error, stage, changeset, _} when is_atom(stage) ->
         log_error_bad_changeset(changeset, stage)
+
         changeset_error =
           changeset
           |> Map.get(:errors)
           |> extract_changeset_error_message
+
         error_message = "Invalid #{stage} changeset #{changeset_error}"
         log_and_return_badrequest(error_message)
     end
@@ -117,6 +120,7 @@ defmodule Cadet.Updater.XMLParser do
         |> nested_tuple_to_list()
         |> List.flatten()
         |> Enum.reduce("", fn x, acc -> "#{acc <> to_string(x)} " end)
+
       {:error, {:bad_request, "Invalid XML #{error_message}"}}
   end
 
@@ -126,7 +130,7 @@ defmodule Cadet.Updater.XMLParser do
     |> List.foldr("", fn x, acc -> "#{acc <> x} " end)
   end
 
-  @spec process_assessment(String.t()) :: {:ok, map()} | {:error, String.t}
+  @spec process_assessment(String.t()) :: {:ok, map()} | {:error, String.t()}
   defp process_assessment(xml) do
     open_at =
       Timex.now()
@@ -164,7 +168,6 @@ defmodule Cadet.Updater.XMLParser do
     end
 
     {:ok, assessment_params}
-
   rescue
     # This error is raised by xpath/3 when TASK does not exist (hence is equal to nil)
     Protocol.UndefinedError ->
@@ -188,7 +191,7 @@ defmodule Cadet.Updater.XMLParser do
     type
   end
 
-  @spec process_questions(String.t()) :: {:ok, [map()]} | {:error, String.t}
+  @spec process_questions(String.t()) :: {:ok, [map()]} | {:error, String.t()}
   defp process_questions(xml) do
     default_library = xpath(xml, ~x"//TASK/DEPLOYMENT"e)
     default_grading_library = xpath(xml, ~x"//TASK/GRADERDEPLOYMENT"e)
@@ -234,7 +237,7 @@ defmodule Cadet.Updater.XMLParser do
     Logger.error("Changeset: #{inspect(changeset, pretty: true)}")
   end
 
-  @spec process_question_by_question_type(map()) :: map() | {:error, String.t}
+  @spec process_question_by_question_type(map()) :: map() | {:error, String.t()}
   defp process_question_by_question_type(question) do
     question[:entity]
     |> process_question_entity_by_type(question[:type])
@@ -297,7 +300,7 @@ defmodule Cadet.Updater.XMLParser do
     {:error, "Invalid question type"}
   end
 
-  @spec process_question_library(map(), any(), any()) :: map() | {:error, String.t}
+  @spec process_question_library(map(), any(), any()) :: map() | {:error, String.t()}
   defp process_question_library(question, default_library, default_grading_library) do
     library = xpath(question[:entity], ~x"./DEPLOYMENT"o) || default_library
 
@@ -361,7 +364,7 @@ defmodule Cadet.Updater.XMLParser do
   end
 
   defp nested_tuple_to_list(tuple) when is_tuple(tuple) do
-    tuple |> Tuple.to_list |> Enum.map(&nested_tuple_to_list/1)
+    tuple |> Tuple.to_list() |> Enum.map(&nested_tuple_to_list/1)
   end
 
   defp nested_tuple_to_list(x), do: x

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -36,7 +36,8 @@ defmodule CadetWeb.AssessmentsController do
   end
 
   def publish(conn, %{"id" => id, "togglePublishTo" => toggle_publish_to}) do
-    result = Assessments.toggle_publish_assessment(conn.assigns.current_user, id, toggle_publish_to)
+    result =
+      Assessments.toggle_publish_assessment(conn.assigns.current_user, id, toggle_publish_to)
 
     case result do
       {:ok, _nil} ->
@@ -52,7 +53,14 @@ defmodule CadetWeb.AssessmentsController do
   def update(conn, %{"id" => id, "closeAt" => close_at, "openAt" => open_at}) do
     formatted_close_date = elem(DateTime.from_iso8601(close_at), 1)
     formatted_open_date = elem(DateTime.from_iso8601(open_at), 1)
-    result = Assessments.change_dates_assessment(conn.assigns.current_user, id, formatted_close_date, formatted_open_date)
+
+    result =
+      Assessments.change_dates_assessment(
+        conn.assigns.current_user,
+        id,
+        formatted_close_date,
+        formatted_open_date
+      )
 
     case result do
       {:ok, _nil} ->
@@ -81,11 +89,14 @@ defmodule CadetWeb.AssessmentsController do
 
   def create(conn, %{"assessment" => assessment, "forceUpdate" => force_update}) do
     role = conn.assigns[:current_user].role
+
     if role == :student do
       send_resp(conn, :forbidden, "User not allowed to create")
     else
-      file = assessment["file"].path
-      |> File.read!()
+      file =
+        assessment["file"].path
+        |> File.read!()
+
       result =
         case force_update do
           "true" -> parse_xml(file, true)
@@ -94,7 +105,7 @@ defmodule CadetWeb.AssessmentsController do
 
       case result do
         :ok ->
-          if (force_update == "true") do
+          if force_update == "true" do
             send_resp(conn, 200, "Force Update OK")
           else
             send_resp(conn, 200, "OK")

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -35,8 +35,8 @@ defmodule CadetWeb.AssessmentsController do
     end
   end
 
-  def update(conn, %{"id" => id, "bool" => bool}) do
-    result = Assessments.toggle_publish_assessment(conn.assigns.current_user, id, bool)
+  def update(conn, %{"id" => id, "togglePublishTo" => toggle_publish_to}) do
+    result = Assessments.toggle_publish_assessment(conn.assigns.current_user, id, toggle_publish_to)
 
     case result do
       {:ok, _nil} ->
@@ -82,7 +82,7 @@ defmodule CadetWeb.AssessmentsController do
   def create(conn, %{"assessment" => assessment, "forceUpdate" => force_update}) do
     file = assessment["file"].path
       |> File.read!()
-    result = 
+    result =
       case force_update do
         "true" -> parse_xml(file, true)
         "false" -> parse_xml(file, false)

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -219,11 +219,8 @@ defmodule CadetWeb.AssessmentsController do
 
     security([%{JWT: []}])
 
-    consumes("application/json")
-
     parameters do
       assessmentId(:path, :integer, "assessment id", required: true)
-      togglePublishTo(:body, :boolean, "toggles assessment publish state", required: true)
     end
 
     response(200, "OK")

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -4,6 +4,7 @@ defmodule CadetWeb.AssessmentsController do
   use PhoenixSwagger
 
   alias Cadet.Assessments
+  import Cadet.Updater.XMLParser, only: [parse_xml: 2]
 
   def submit(conn, %{"assessmentid" => assessment_id}) when is_ecto_id(assessment_id) do
     case Assessments.finalise_submission(assessment_id, conn.assigns.current_user) do
@@ -19,7 +20,7 @@ defmodule CadetWeb.AssessmentsController do
 
   def index(conn, _) do
     user = conn.assigns[:current_user]
-    {:ok, assessments} = Assessments.all_published_assessments(user)
+    {:ok, assessments} = Assessments.all_assessments(user)
 
     render(conn, "index.json", assessments: assessments)
   end
@@ -31,6 +32,75 @@ defmodule CadetWeb.AssessmentsController do
     case Assessments.assessment_with_questions_and_answers(assessment_id, user, password) do
       {:ok, assessment} -> render(conn, "show.json", assessment: assessment)
       {:error, {status, message}} -> send_resp(conn, status, message)
+    end
+  end
+
+  def update(conn, %{"id" => id, "bool" => bool}) do
+    result = Assessments.toggle_publish_assessment(conn.assigns.current_user, id, bool)
+
+    case result do
+      {:ok, _nil} ->
+        send_resp(conn, 200, "OK")
+
+      {:error, {status, message}} ->
+        conn
+        |> put_status(status)
+        |> text(message)
+    end
+  end
+
+  def update(conn, %{"id" => id, "closeAt" => close_at, "openAt" => open_at}) do
+    formatted_close_date = elem(DateTime.from_iso8601(close_at), 1)
+    formatted_open_date = elem(DateTime.from_iso8601(open_at), 1)
+    result = Assessments.change_dates_assessment(conn.assigns.current_user, id, formatted_close_date, formatted_open_date)
+
+    case result do
+      {:ok, _nil} ->
+        send_resp(conn, 200, "OK")
+
+      {:error, {status, message}} ->
+        conn
+        |> put_status(status)
+        |> text(message)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    result = Assessments.delete_assessment(conn.assigns.current_user, id)
+
+    case result do
+      {:ok, _nil} ->
+        send_resp(conn, 200, "OK")
+
+      {:error, {status, message}} ->
+        conn
+        |> put_status(status)
+        |> text(message)
+    end
+  end
+
+  def create(conn, %{"assessment" => assessment, "forceUpdate" => force_update}) do
+    file = assessment["file"].path
+      |> File.read!()
+    result = 
+      case force_update do
+        "true" -> parse_xml(file, true)
+        "false" -> parse_xml(file, false)
+      end
+
+    case result do
+      :ok ->
+        if (force_update == "true") do
+          send_resp(conn, 200, "Force Update OK")
+        else
+          send_resp(conn, 200, "OK")
+        end
+
+      {:ok, warning_message} ->
+        send_resp(conn, 200, warning_message)
+
+      {:error, {status, message}} ->
+        send_resp(conn, status, message)
     end
   end
 

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -37,58 +37,6 @@ defmodule CadetWeb.AssessmentsController do
     end
   end
 
-  def publish(conn, %{"id" => id, "togglePublishTo" => toggle_publish_to}) do
-    result =
-      Assessments.toggle_publish_assessment(conn.assigns.current_user, id, toggle_publish_to)
-
-    case result do
-      {:ok, _nil} ->
-        send_resp(conn, 200, "OK")
-
-      {:error, {status, message}} ->
-        conn
-        |> put_status(status)
-        |> text(message)
-    end
-  end
-
-  def update(conn, %{"id" => id, "closeAt" => close_at, "openAt" => open_at}) do
-    formatted_close_date = elem(DateTime.from_iso8601(close_at), 1)
-    formatted_open_date = elem(DateTime.from_iso8601(open_at), 1)
-
-    result =
-      Assessments.change_dates_assessment(
-        conn.assigns.current_user,
-        id,
-        formatted_close_date,
-        formatted_open_date
-      )
-
-    case result do
-      {:ok, _nil} ->
-        send_resp(conn, 200, "OK")
-
-      {:error, {status, message}} ->
-        conn
-        |> put_status(status)
-        |> text(message)
-    end
-  end
-
-  def delete(conn, %{"id" => id}) do
-    result = Assessments.delete_assessment(conn.assigns.current_user, id)
-
-    case result do
-      {:ok, _nil} ->
-        send_resp(conn, 200, "OK")
-
-      {:error, {status, message}} ->
-        conn
-        |> put_status(status)
-        |> text(message)
-    end
-  end
-
   def create(conn, %{"assessment" => assessment, "forceUpdate" => force_update}) do
     role = conn.assigns[:current_user].role
 
@@ -119,6 +67,62 @@ defmodule CadetWeb.AssessmentsController do
       end
     else
       send_resp(conn, :forbidden, "User not allowed to create assessment")
+    end
+  end
+
+  def delete(conn, %{"assessmentid" => assessment_id}) do
+    result = Assessments.delete_assessment(conn.assigns.current_user, assessment_id)
+
+    case result do
+      {:ok, _nil} ->
+        send_resp(conn, 200, "OK")
+
+      {:error, {status, message}} ->
+        conn
+        |> put_status(status)
+        |> text(message)
+    end
+  end
+
+  def publish(conn, %{"assessmentid" => assessment_id, "togglePublishTo" => toggle_publish_to}) do
+    result =
+      Assessments.toggle_publish_assessment(
+        conn.assigns.current_user,
+        assessment_id,
+        toggle_publish_to
+      )
+
+    case result do
+      {:ok, _nil} ->
+        send_resp(conn, 200, "OK")
+
+      {:error, {status, message}} ->
+        conn
+        |> put_status(status)
+        |> text(message)
+    end
+  end
+
+  def update(conn, %{"assessmentid" => assessment_id, "closeAt" => close_at, "openAt" => open_at}) do
+    formatted_close_date = elem(DateTime.from_iso8601(close_at), 1)
+    formatted_open_date = elem(DateTime.from_iso8601(open_at), 1)
+
+    result =
+      Assessments.change_dates_assessment(
+        conn.assigns.current_user,
+        assessment_id,
+        formatted_close_date,
+        formatted_open_date
+      )
+
+    case result do
+      {:ok, _nil} ->
+        send_resp(conn, 200, "OK")
+
+      {:error, {status, message}} ->
+        conn
+        |> put_status(status)
+        |> text(message)
     end
   end
 
@@ -178,6 +182,8 @@ defmodule CadetWeb.AssessmentsController do
 
     security([%{JWT: []}])
 
+    consumes("application/json")
+
     parameters do
       assessment(:body, :file, "assessment to create or update", required: true)
       forceUpdate(:body, :boolean, "force update", required: true)
@@ -189,7 +195,7 @@ defmodule CadetWeb.AssessmentsController do
   end
 
   swagger_path :delete do
-    PhoenixSwagger.Path.delete("/assessments/:id")
+    PhoenixSwagger.Path.delete("/assessments/:assessmentid")
 
     summary("Deletes an assessment")
 
@@ -204,11 +210,13 @@ defmodule CadetWeb.AssessmentsController do
   end
 
   swagger_path :publish do
-    post("/assessments/publish/:id")
+    post("/assessments/publish/:assessmentid")
 
     summary("Toggles an assessment between published and unpublished")
 
     security([%{JWT: []}])
+
+    consumes("application/json")
 
     parameters do
       assessmentId(:path, :integer, "assessment id", required: true)
@@ -220,11 +228,13 @@ defmodule CadetWeb.AssessmentsController do
   end
 
   swagger_path :update do
-    post("/assessments/update/:id")
+    post("/assessments/update/:assessmentid")
 
     summary("Changes the open/close date of an assessment")
 
     security([%{JWT: []}])
+
+    consumes("application/json")
 
     parameters do
       assessmentId(:path, :integer, "assessment id", required: true)

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -88,12 +88,11 @@ defmodule CadetWeb.AssessmentsController do
     end
   end
 
-  def publish(conn, %{"assessmentid" => assessment_id, "togglePublishTo" => toggle_publish_to}) do
+  def publish(conn, %{"assessmentid" => assessment_id}) do
     result =
       Assessments.toggle_publish_assessment(
         conn.assigns.current_user,
-        assessment_id,
-        toggle_publish_to
+        assessment_id
       )
 
     case result do

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -54,19 +54,23 @@ defmodule CadetWeb.AssessmentsController do
       case result do
         :ok ->
           if force_update == "true" do
-            send_resp(conn, 200, "Force Update OK")
+            text(conn, "Force Update OK")
           else
-            send_resp(conn, 200, "OK")
+            text(conn, "OK")
           end
 
         {:ok, warning_message} ->
-          send_resp(conn, 200, warning_message)
+          text(conn, warning_message)
 
         {:error, {status, message}} ->
-          send_resp(conn, status, message)
+          conn
+          |> put_status(status)
+          |> text(message)
       end
     else
-      send_resp(conn, :forbidden, "User not allowed to create assessment")
+      conn
+      |> put_status(:forbidden)
+      |> text("User not allowed to create assessment")
     end
   end
 
@@ -75,7 +79,7 @@ defmodule CadetWeb.AssessmentsController do
 
     case result do
       {:ok, _nil} ->
-        send_resp(conn, 200, "OK")
+        text(conn, "OK")
 
       {:error, {status, message}} ->
         conn
@@ -94,7 +98,7 @@ defmodule CadetWeb.AssessmentsController do
 
     case result do
       {:ok, _nil} ->
-        send_resp(conn, 200, "OK")
+        text(conn, "OK")
 
       {:error, {status, message}} ->
         conn
@@ -117,7 +121,7 @@ defmodule CadetWeb.AssessmentsController do
 
     case result do
       {:ok, _nil} ->
-        send_resp(conn, 200, "OK")
+        text(conn, "OK")
 
       {:error, {status, message}} ->
         conn

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -293,6 +293,8 @@ defmodule CadetWeb.AssessmentsController do
             coverImage(:string, "The URL to the cover picture", required: true)
 
             private(:boolean, "Is this an private assessment?", required: true)
+
+            isPublished(:boolean, "Is the assessment published?", required: true)
           end
         end,
       Assessment:

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -39,10 +39,10 @@ defmodule CadetWeb.Router do
 
     get("/assessments", AssessmentsController, :index)
     post("/assessments", AssessmentsController, :create)
-    delete("/assessments/:id", AssessmentsController, :delete)
+    delete("/assessments/:assessmentid", AssessmentsController, :delete)
     post("/assessments/:id", AssessmentsController, :show)
-    post("/assessments/publish/:id", AssessmentsController, :publish)
-    post("/assessments/update/:id", AssessmentsController, :update)
+    post("/assessments/publish/:assessmentid", AssessmentsController, :publish)
+    post("/assessments/update/:assessmentid", AssessmentsController, :update)
     post("/assessments/:assessmentid/submit", AssessmentsController, :submit)
     post("/assessments/question/:questionid/submit", AnswerController, :submit)
 

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -38,7 +38,11 @@ defmodule CadetWeb.Router do
     resources("/sourcecast", SourcecastController, only: [:create, :delete])
 
     get("/assessments", AssessmentsController, :index)
+    post("/assessments", AssessmentsController, :create)
+    delete("/assessments/:id", AssessmentsController, :delete)
     post("/assessments/:id", AssessmentsController, :show)
+    post("/assessments/publish/:id", AssessmentsController, :update)
+    post("/assessments/update/:id", AssessmentsController, :update)
     post("/assessments/:assessmentid/submit", AssessmentsController, :submit)
     post("/assessments/question/:questionid/submit", AnswerController, :submit)
 

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -41,7 +41,7 @@ defmodule CadetWeb.Router do
     post("/assessments", AssessmentsController, :create)
     delete("/assessments/:id", AssessmentsController, :delete)
     post("/assessments/:id", AssessmentsController, :show)
-    post("/assessments/publish/:id", AssessmentsController, :update)
+    post("/assessments/publish/:id", AssessmentsController, :publish)
     post("/assessments/update/:id", AssessmentsController, :update)
     post("/assessments/:assessmentid/submit", AssessmentsController, :submit)
     post("/assessments/question/:questionid/submit", AnswerController, :submit)

--- a/lib/cadet_web/views/assessments_view.ex
+++ b/lib/cadet_web/views/assessments_view.ex
@@ -26,7 +26,8 @@ defmodule CadetWeb.AssessmentsView do
       xp: &(&1.xp || 0),
       grade: &(&1.grade || 0),
       coverImage: :cover_picture,
-      private: &password_protected?(&1.password)
+      private: &password_protected?(&1.password),
+      isPublished: :is_published
     })
   end
 

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -1502,7 +1502,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
     end
 
     @tag authenticate: :staff
-    test "not allowed to set close time to before current time", %{conn: conn} do
+    test "successful, set close time to before current time", %{conn: conn} do
       open_at =
         Timex.now()
         |> Timex.beginning_of_day()
@@ -1531,12 +1531,12 @@ defmodule CadetWeb.AssessmentsControllerTest do
         |> post(build_url_update(assessment.id), new_dates)
 
       assessment = Repo.get(Assessment, assessment.id)
-      assert response(conn, 400) == "New end date should occur after current time"
-      assert [assessment.open_at, assessment.close_at] == [open_at, close_at]
+      assert response(conn, 200) == "OK"
+      assert [assessment.open_at, assessment.close_at] == [open_at, new_close_at]
     end
 
     @tag authenticate: :staff
-    test "not allowed to set open time to before current time", %{conn: conn} do
+    test "successful, set open time to before current time", %{conn: conn} do
       open_at =
         Timex.now()
         |> Timex.beginning_of_day()
@@ -1565,8 +1565,8 @@ defmodule CadetWeb.AssessmentsControllerTest do
         |> post(build_url_update(assessment.id), new_dates)
 
       assessment = Repo.get(Assessment, assessment.id)
-      assert response(conn, 400) == "New Opening date should occur after current time"
-      assert [assessment.open_at, assessment.close_at] == [open_at, close_at]
+      assert response(conn, 200) == "OK"
+      assert [assessment.open_at, assessment.close_at] == [new_open_at, close_at]
     end
   end
 


### PR DESCRIPTION
## Context
This PR is for modifying the backend API to support the Assessment Uploader component for the CP3018 Staff Dashboard project. The Assessment Uploader, also called the GroundControl, provides an interface for staff to manage assessments for the course. Staff can upload, delete, publish or update assessments through this interface.

## Implementation
+ Added multiple routes to aid with the uploading, deleting, publishing and updating of assessments.
+ Modified and added various methods in `xml_parser`and in `assessments` to handle the additional routes. The 'parse_xml' method now returns the error message if there is any error in parsing.
+ Modified how the `is_published` field for assessments work. Unpublished assessments are now viewable by staff and admin.
+ Assessments have the 'is_published' field set to false by default when it is parsed.
+ Changed the `all_published_assessments` in `cadet/assessments/assessments.ex` to `all_assessments`. Returns all assessments/all published assessments depending on the role of the user.
+ Added a new field, `isPublished`, to the assessment overview.
+ XML files for assessments no longer require the 'startdate' and 'enddate' tags. The assessments will now have a default start and end date relative to the time it was uploaded at.
+ Existing tests have been modified to accommodate the modifications made.


## Other Information
Corresponding PR to `cadet-frontend`: [PR 1080](https://github.com/source-academy/cadet-frontend/pull/1080)
More info on the wiki: [Assessment Uploader](https://github.com/source-academy/cadet/wiki/Staff-Dashboard#assessment-uploader)