### PR TITLE
Build all testcases for staff when grading submissions

### DIFF
--- a/lib/cadet_web/views/grading_view.ex
+++ b/lib/cadet_web/views/grading_view.ex
@@ -35,7 +35,7 @@ defmodule CadetWeb.GradingView do
     results = build_autograding_results(answer.autograding_results)
 
     %{question: answer.question, assessment_type: answer.question.assessment.type}
-    |> build_question_by_assessment_type()
+    |> build_question_by_assessment_type(true)
     |> Map.put(:answer, answer.answer["code"] || answer.answer["choice_id"])
     |> Map.put(:autogradingStatus, answer.autograding_status)
     |> Map.put(:autogradingResults, results)

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -267,18 +267,14 @@ defmodule CadetWeb.GradingControllerTest do
                             do: {Atom.to_string(k), v}
                       end
                     ) ++
-                      if &1.question.assessment.type == :path do
-                        Enum.map(
-                          &1.question.question.private,
-                          fn testcase ->
-                            for {k, v} <- testcase,
-                                into: %{"type" => "hidden"},
-                                do: {Atom.to_string(k), v}
-                          end
-                        )
-                      else
-                        []
-                      end,
+                      Enum.map(
+                        &1.question.question.private,
+                        fn testcase ->
+                          for {k, v} <- testcase,
+                              into: %{"type" => "private"},
+                              do: {Atom.to_string(k), v}
+                        end
+                      ),
                   "solutionTemplate" => &1.question.question.template,
                   "type" => "#{&1.question.type}",
                   "id" => &1.question.id,
@@ -405,18 +401,14 @@ defmodule CadetWeb.GradingControllerTest do
                             do: {Atom.to_string(k), v}
                       end
                     ) ++
-                      if &1.question.assessment.type == :path do
-                        Enum.map(
-                          &1.question.question.private,
-                          fn testcase ->
-                            for {k, v} <- testcase,
-                                into: %{"type" => "hidden"},
-                                do: {Atom.to_string(k), v}
-                          end
-                        )
-                      else
-                        []
-                      end,
+                      Enum.map(
+                        &1.question.question.private,
+                        fn testcase ->
+                          for {k, v} <- testcase,
+                              into: %{"type" => "private"},
+                              do: {Atom.to_string(k), v}
+                        end
+                      ),
                   "solutionTemplate" => &1.question.question.template,
                   "type" => "#{&1.question.type}",
                   "id" => &1.question.id,
@@ -971,18 +963,14 @@ defmodule CadetWeb.GradingControllerTest do
                             do: {Atom.to_string(k), v}
                       end
                     ) ++
-                      if &1.question.assessment.type == :path do
-                        Enum.map(
-                          &1.question.question.private,
-                          fn testcase ->
-                            for {k, v} <- testcase,
-                                into: %{"type" => "hidden"},
-                                do: {Atom.to_string(k), v}
-                          end
-                        )
-                      else
-                        []
-                      end,
+                      Enum.map(
+                        &1.question.question.private,
+                        fn testcase ->
+                          for {k, v} <- testcase,
+                              into: %{"type" => "private"},
+                              do: {Atom.to_string(k), v}
+                        end
+                      ),
                   "solutionTemplate" => &1.question.question.template,
                   "type" => "#{&1.question.type}",
                   "id" => &1.question.id,


### PR DESCRIPTION
## Build all testcases for staff when grading submissions
Summary: Adds the minor feature request #445.

### Related PRs
Please review this PR in conjunction with the PR on cadet-frontend: https://github.com/source-academy/cadet-frontend/pull/1359

### Changelog
- Build all testcases (public and private) of the corresponding assessment in the response from the `GET /grading/:submissionid` endpoint
  - Only staff are authorised to access this endpoint for grading purposes; private testcases are not built when viewing an assessment via the `GET /assessments/:assessmentid` endpoint
- Update corresponding Grading controller tests

Last updated 13 Jul 2020, 11:45PM