### PR TITLE
Replace assessment type enum with equivalent string values

### DIFF
--- a/lib/cadet/assessments/assessment.ex
+++ b/lib/cadet/assessments/assessment.ex
@@ -54,6 +54,7 @@ defmodule Cadet.Assessments.Assessment do
     |> cast_attachments(params, @optional_file_fields)
     |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> validate_inclusion(:type, @assessment_types)
     |> validate_open_close_date
   end
 

--- a/lib/cadet/assessments/assessment.ex
+++ b/lib/cadet/assessments/assessment.ex
@@ -6,7 +6,10 @@ defmodule Cadet.Assessments.Assessment do
   use Cadet, :model
   use Arc.Ecto.Schema
 
-  alias Cadet.Assessments.{AssessmentAccess, AssessmentType, Question, SubmissionStatus, Upload}
+  alias Cadet.Assessments.{AssessmentAccess, Question, SubmissionStatus, Upload}
+
+  @assessment_types ~w(contest mission path practical sidequest)
+  def assessment_types, do: @assessment_types
 
   schema "assessments" do
     field(:access, AssessmentAccess, virtual: true, default: :public)
@@ -20,7 +23,7 @@ defmodule Cadet.Assessments.Assessment do
     field(:graded_count, :integer, virtual: true)
     field(:title, :string)
     field(:is_published, :boolean, default: false)
-    field(:type, AssessmentType)
+    field(:type, :string)
     field(:summary_short, :string)
     field(:summary_long, :string)
     field(:open_at, :utc_datetime_usec)

--- a/lib/cadet/assessments/assessment_type.ex
+++ b/lib/cadet/assessments/assessment_type.ex
@@ -1,9 +1,0 @@
-import EctoEnum
-
-defenum(Cadet.Assessments.AssessmentType, :assessment_type, [
-  :path,
-  :mission,
-  :sidequest,
-  :contest,
-  :practical
-])

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -14,7 +14,7 @@ defmodule Cadet.Assessments do
   alias Ecto.Multi
 
   @xp_early_submission_max_bonus 100
-  @xp_bonus_assessment_type ~w(mission sidequest)a
+  @xp_bonus_assessment_type ~w(mission sidequest)
   # @submit_answer_roles ~w(student staff admin)a
   @change_dates_assessment_role ~w(staff admin)a
   @delete_assessment_role ~w(staff admin)a
@@ -1046,7 +1046,7 @@ defmodule Cadet.Assessments do
         |> where(
           [ans, s, st, a],
           not is_nil(st.group_id) and s.status == ^:submitted and
-            a.type in ^[:mission, :sidequest]
+            a.type in ^["mission", "sidequest"]
         )
         |> group_by([ans, s, st, a], s.id)
         |> select([ans, s, st, a], %{
@@ -1065,10 +1065,10 @@ defmodule Cadet.Assessments do
         |> select([t, g, l], %{
           group_name: g.name,
           leader_name: l.name,
-          ungraded_missions: filter(count(), t.type == ^:mission and t.num_ungraded > 0),
-          submitted_missions: filter(count(), t.type == ^:mission),
-          ungraded_sidequests: filter(count(), t.type == ^:sidequest and t.num_ungraded > 0),
-          submitted_sidequests: filter(count(), t.type == ^:sidequest)
+          ungraded_missions: filter(count(), t.type == "mission" and t.num_ungraded > 0),
+          submitted_missions: filter(count(), t.type == "mission"),
+          ungraded_sidequests: filter(count(), t.type == "sidequest" and t.num_ungraded > 0),
+          submitted_sidequests: filter(count(), t.type == "sidequest")
         })
         |> Repo.all()
 

--- a/lib/cadet_web/views/assessments_helpers.ex
+++ b/lib/cadet_web/views/assessments_helpers.ex
@@ -5,7 +5,7 @@ defmodule CadetWeb.AssessmentsHelpers do
 
   import CadetWeb.ViewHelper
 
-  @graded_assessment_types ~w(mission sidequest contest)a
+  @graded_assessment_types ~w(mission sidequest contest)
 
   defp build_library(%{library: library}) do
     transform_map_for_view(library, %{
@@ -164,7 +164,7 @@ defmodule CadetWeb.AssessmentsHelpers do
           Enum.map(&1["private"], fn testcase -> build_testcase(testcase, "private") end)
         )
 
-      assessment_type == :path ->
+      assessment_type == "path" ->
         &Enum.concat(
           Enum.map(&1["public"], fn testcase -> build_testcase(testcase, "public") end),
           Enum.map(&1["private"], fn testcase -> build_testcase(testcase, "hidden") end)
@@ -177,7 +177,7 @@ defmodule CadetWeb.AssessmentsHelpers do
 
   defp build_postpend(%{assessment_type: assessment_type}) do
     case assessment_type do
-      :path -> & &1["postpend"]
+      "path" -> & &1["postpend"]
       # Create a 1-arity function to return an empty postpend for non-paths
       _ -> fn _question -> "" end
     end

--- a/priv/repo/migrations/20180119002258_create_assessments.exs
+++ b/priv/repo/migrations/20180119002258_create_assessments.exs
@@ -1,16 +1,16 @@
 defmodule Cadet.Repo.Migrations.CreateMissions do
   use Ecto.Migration
 
-  alias Cadet.Assessments.AssessmentType
-
   def up do
-    AssessmentType.create_type()
+    Ecto.Migration.execute(
+      "CREATE TYPE assessment_type AS ENUM ('path', 'mission', 'sidequest', 'contest')"
+    )
 
     create table(:assessments) do
       add(:title, :string, null: false)
       add(:summary_short, :text)
       add(:summary_long, :text)
-      add(:type, :assessment_type, null: false)
+      add(:type, :string, null: false)
       add(:open_at, :timestamp, null: false)
       add(:close_at, :timestamp, null: false)
       add(:cover_picture, :string)
@@ -31,6 +31,6 @@ defmodule Cadet.Repo.Migrations.CreateMissions do
   def down do
     drop(table(:assessments))
 
-    AssessmentType.drop_type()
+    Ecto.Migration.execute("DROP TYPE assessment_type")
   end
 end

--- a/priv/repo/migrations/20200812202222_remove_assessment_type_enum.exs
+++ b/priv/repo/migrations/20200812202222_remove_assessment_type_enum.exs
@@ -1,0 +1,20 @@
+defmodule Cadet.Repo.Migrations.RemoveAssessmentTypeEnum do
+  use Ecto.Migration
+
+  def change do
+    alter table(:assessments) do
+      add(:type_new, :string)
+    end
+
+    Ecto.Migration.execute("UPDATE assessments SET type_new = type::text")
+
+    alter table(:assessments) do
+      modify(:type_new, :string, null: false)
+      remove(:type)
+    end
+
+    rename(table(:assessments), :type_new, to: :type)
+
+    Ecto.Migration.execute("DROP TYPE assessment_type")
+  end
+end

--- a/test/cadet/assessments/assessment_test.exs
+++ b/test/cadet/assessments/assessment_test.exs
@@ -7,7 +7,7 @@ defmodule Cadet.Assessments.AssessmentTest do
     test "valid changesets" do
       assert_changeset(
         %{
-          type: :mission,
+          type: "mission",
           title: "mission",
           number: "M#{Enum.random(0..10)}",
           open_at: Timex.now() |> Timex.to_unix() |> Integer.to_string(),
@@ -18,7 +18,7 @@ defmodule Cadet.Assessments.AssessmentTest do
 
       assert_changeset(
         %{
-          type: :mission,
+          type: "mission",
           title: "mission",
           number: "M#{Enum.random(0..10)}",
           open_at: Timex.now() |> Timex.to_unix() |> Integer.to_string(),
@@ -31,7 +31,7 @@ defmodule Cadet.Assessments.AssessmentTest do
     end
 
     test "invalid changesets" do
-      assert_changeset(%{type: :mission, title: "mission", max_grade: 100}, :invalid)
+      assert_changeset(%{type: "mission", title: "mission", max_grade: 100}, :invalid)
 
       assert_changeset(
         %{

--- a/test/cadet/assessments/assessment_test.exs
+++ b/test/cadet/assessments/assessment_test.exs
@@ -18,7 +18,7 @@ defmodule Cadet.Assessments.AssessmentTest do
 
       assert_changeset(
         %{
-          type: "mission",
+          type: Enum.random(Assessment.assessment_types()),
           title: "mission",
           number: "M#{Enum.random(0..10)}",
           open_at: Timex.now() |> Timex.to_unix() |> Integer.to_string(),
@@ -39,6 +39,21 @@ defmodule Cadet.Assessments.AssessmentTest do
           open_at: Timex.now(),
           close_at: Timex.shift(Timex.now(), days: 7),
           max_grade: 100
+        },
+        :invalid
+      )
+
+      assert_changeset(
+        %{
+          type: "misc",
+          title: "invalid type",
+          number: "M#{Enum.random(1..10)}",
+          open_at: Timex.now() |> Timex.to_unix() |> Integer.to_string(),
+          close_at:
+            Timex.now()
+            |> Timex.shift(days: Enum.random(1..7))
+            |> Timex.to_unix()
+            |> Integer.to_string()
         },
         :invalid
       )

--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -2,17 +2,17 @@ defmodule Cadet.AssessmentsTest do
   use Cadet.DataCase
 
   alias Cadet.Assessments
-  alias Cadet.Assessments.{Assessment, AssessmentType, Question}
+  alias Cadet.Assessments.{Assessment, Question}
 
   test "create assessments of all types" do
-    for type <- AssessmentType.__enum_map__() do
-      title_string = Atom.to_string(type)
+    for type <- Assessment.assessment_types() do
+      title_string = type
 
       {_res, assessment} =
         Assessments.create_assessment(%{
           title: title_string,
           type: type,
-          number: "#{type |> Atom.to_string() |> String.upcase()}#{Enum.random(0..10)}",
+          number: "#{type |> String.upcase()}#{Enum.random(0..10)}",
           open_at: Timex.now(),
           close_at: Timex.shift(Timex.now(), days: 7)
         })

--- a/test/cadet/jobs/autograder/grading_job_test.exs
+++ b/test/cadet/jobs/autograder/grading_job_test.exs
@@ -27,7 +27,7 @@ defmodule Cadet.Autograder.GradingJobTest do
           is_published: true,
           open_at: Timex.shift(Timex.now(), days: -5),
           close_at: Timex.shift(Timex.now(), hours: -4),
-          type: :mission
+          type: "mission"
         })
 
       questions =
@@ -109,7 +109,7 @@ defmodule Cadet.Autograder.GradingJobTest do
           is_published: true,
           open_at: Timex.shift(Timex.now(), days: -5),
           close_at: Timex.shift(Timex.now(), hours: -4),
-          type: :mission
+          type: "mission"
         })
 
       questions =
@@ -325,7 +325,7 @@ defmodule Cadet.Autograder.GradingJobTest do
           is_published: true,
           open_at: Timex.shift(Timex.now(), days: -5),
           close_at: Timex.shift(Timex.now(), hours: -4),
-          type: :mission
+          type: "mission"
         })
 
       questions =

--- a/test/cadet/jobs/autograder/utilities_test.exs
+++ b/test/cadet/jobs/autograder/utilities_test.exs
@@ -1,7 +1,7 @@
 defmodule Cadet.Autograder.UtilitiesTest do
   use Cadet.DataCase
 
-  alias Cadet.Assessments.AssessmentType
+  alias Cadet.Assessments.Assessment
   alias Cadet.Autograder.Utilities
 
   describe "fetch_assessments_due_yesterday" do
@@ -11,7 +11,7 @@ defmodule Cadet.Autograder.UtilitiesTest do
           is_published: true,
           open_at: Timex.shift(Timex.now(), days: -5),
           close_at: Timex.shift(Timex.now(), hours: -4),
-          type: :mission
+          type: "mission"
         })
 
       past =
@@ -19,7 +19,7 @@ defmodule Cadet.Autograder.UtilitiesTest do
           is_published: true,
           open_at: Timex.shift(Timex.now(), days: -5),
           close_at: Timex.shift(Timex.now(), days: -4),
-          type: :mission
+          type: "mission"
         })
 
       future =
@@ -27,7 +27,7 @@ defmodule Cadet.Autograder.UtilitiesTest do
           is_published: true,
           open_at: Timex.shift(Timex.now(), days: -3),
           close_at: Timex.shift(Timex.now(), days: 4),
-          type: :mission
+          type: "mission"
         })
 
       for assessment <- yesterday ++ past ++ future do
@@ -40,7 +40,7 @@ defmodule Cadet.Autograder.UtilitiesTest do
 
     test "it return only paths, missions, sidequests" do
       assessments =
-        for type <- AssessmentType.__enum_map__() do
+        for type <- Assessment.assessment_types() do
           insert(:assessment, %{
             is_published: true,
             open_at: Timex.shift(Timex.now(), days: -5),
@@ -53,7 +53,7 @@ defmodule Cadet.Autograder.UtilitiesTest do
         insert_list(2, :programming_question, %{assessment: assessment})
       end
 
-      assert get_assessments_ids(Enum.filter(assessments, &(&1.type != :contest))) ==
+      assert get_assessments_ids(Enum.filter(assessments, &(&1.type != "contest"))) ==
                get_assessments_ids(Utilities.fetch_assessments_due_yesterday())
     end
 
@@ -63,7 +63,7 @@ defmodule Cadet.Autograder.UtilitiesTest do
           is_published: true,
           open_at: Timex.shift(Timex.now(), days: -5),
           close_at: Timex.shift(Timex.now(), hours: -4),
-          type: :mission
+          type: "mission"
         })
 
       insert_list(5, :programming_question, %{assessment: assessment})

--- a/test/cadet/updater/xml_parser_test.exs
+++ b/test/cadet/updater/xml_parser_test.exs
@@ -1,5 +1,5 @@
 defmodule Cadet.Updater.XMLParserTest do
-  alias Cadet.Assessments.{Assessment, AssessmentType, Question}
+  alias Cadet.Assessments.{Assessment, Question}
   alias Cadet.Test.XMLGenerator
   alias Cadet.Updater.XMLParser
 
@@ -11,7 +11,7 @@ defmodule Cadet.Updater.XMLParserTest do
   setup do
     assessments =
       Enum.map(
-        AssessmentType.__enum_map__(),
+        Assessment.assessment_types(),
         &build(:assessment, type: &1, is_published: true)
       )
 

--- a/test/cadet_web/controllers/grading_controller_test.exs
+++ b/test/cadet_web/controllers/grading_controller_test.exs
@@ -261,7 +261,7 @@ defmodule CadetWeb.GradingControllerTest do
                 "question" => %{
                   "prepend" => &1.question.question.prepend,
                   "postpend" =>
-                    if &1.question.assessment.type == :path do
+                    if &1.question.assessment.type == "path" do
                       &1.question.question.postpend
                     else
                       ""
@@ -395,7 +395,7 @@ defmodule CadetWeb.GradingControllerTest do
                 "question" => %{
                   "prepend" => &1.question.question.prepend,
                   "postpend" =>
-                    if &1.question.assessment.type == :path do
+                    if &1.question.assessment.type == "path" do
                       &1.question.question.postpend
                     else
                       ""
@@ -644,7 +644,7 @@ defmodule CadetWeb.GradingControllerTest do
           open_at: Timex.shift(Timex.now(), hours: -1),
           close_at: Timex.shift(Timex.now(), hours: 500),
           is_published: true,
-          type: :mission
+          type: "mission"
         )
 
       question = insert(:programming_question, assessment: assessment)
@@ -695,7 +695,7 @@ defmodule CadetWeb.GradingControllerTest do
           open_at: Timex.shift(Timex.now(), hours: -1),
           close_at: Timex.shift(Timex.now(), hours: 500),
           is_published: true,
-          type: :mission
+          type: "mission"
         )
 
       question = insert(:programming_question, assessment: assessment)
@@ -729,7 +729,7 @@ defmodule CadetWeb.GradingControllerTest do
           open_at: Timex.shift(Timex.now(), hours: 1),
           close_at: Timex.shift(Timex.now(), hours: 500),
           is_published: true,
-          type: :mission
+          type: "mission"
         )
 
       question = insert(:programming_question, assessment: assessment)
@@ -765,7 +765,7 @@ defmodule CadetWeb.GradingControllerTest do
           open_at: Timex.shift(Timex.now(), hours: -1),
           close_at: Timex.shift(Timex.now(), hours: 500),
           is_published: true,
-          type: :mission
+          type: "mission"
         )
 
       other_grader = insert(:user, role: :staff)
@@ -800,7 +800,7 @@ defmodule CadetWeb.GradingControllerTest do
           open_at: Timex.shift(Timex.now(), hours: -1),
           close_at: Timex.shift(Timex.now(), hours: 500),
           is_published: true,
-          type: :mission
+          type: "mission"
         )
 
       grader = conn.assigns.current_user
@@ -833,7 +833,7 @@ defmodule CadetWeb.GradingControllerTest do
           open_at: Timex.shift(Timex.now(), hours: 1),
           close_at: Timex.shift(Timex.now(), hours: 500),
           is_published: true,
-          type: :mission
+          type: "mission"
         )
 
       grader = conn.assigns.current_user
@@ -870,7 +870,7 @@ defmodule CadetWeb.GradingControllerTest do
           open_at: Timex.shift(Timex.now(), hours: -1),
           close_at: Timex.shift(Timex.now(), hours: 500),
           is_published: true,
-          type: :mission
+          type: "mission"
         )
 
       question = insert(:programming_question, assessment: assessment)
@@ -1025,7 +1025,7 @@ defmodule CadetWeb.GradingControllerTest do
                 "question" => %{
                   "prepend" => &1.question.question.prepend,
                   "postpend" =>
-                    if &1.question.assessment.type == :path do
+                    if &1.question.assessment.type == "path" do
                       &1.question.question.postpend
                     else
                       ""
@@ -1176,10 +1176,10 @@ defmodule CadetWeb.GradingControllerTest do
         %{
           "groupName" => group.name,
           "leaderName" => grader.name,
-          "submittedMissions" => count_submissions(submissions, answers, :mission),
-          "submittedSidequests" => count_submissions(submissions, answers, :sidequest),
-          "ungradedMissions" => count_submissions(submissions, answers, :mission, true),
-          "ungradedSidequests" => count_submissions(submissions, answers, :sidequest, true)
+          "submittedMissions" => count_submissions(submissions, answers, "mission"),
+          "submittedSidequests" => count_submissions(submissions, answers, "sidequest"),
+          "ungradedMissions" => count_submissions(submissions, answers, "mission", true),
+          "ungradedSidequests" => count_submissions(submissions, answers, "sidequest", true)
         }
       ]
 
@@ -1288,7 +1288,7 @@ defmodule CadetWeb.GradingControllerTest do
       insert(:group, %{leader_id: grader.id, leader: grader, mentor_id: mentor.id, mentor: mentor})
 
     students = insert_list(5, :student, %{group: group})
-    mission = insert(:assessment, %{title: "mission", type: :mission, is_published: true})
+    mission = insert(:assessment, %{title: "mission", type: "mission", is_published: true})
 
     questions =
       for index <- 0..2 do

--- a/test/cadet_web/controllers/notification_controller_test.exs
+++ b/test/cadet_web/controllers/notification_controller_test.exs
@@ -73,7 +73,7 @@ defmodule CadetWeb.NotificationControllerTest do
             "submission_id" => nil,
             "type" => Atom.to_string(&1.type),
             "assessment" => %{
-              "type" => Atom.to_string(assessment.type),
+              "type" => assessment.type,
               "title" => assessment.title
             }
           }
@@ -115,7 +115,7 @@ defmodule CadetWeb.NotificationControllerTest do
             "submission_id" => &1.submission_id,
             "type" => Atom.to_string(&1.type),
             "assessment" => %{
-              "type" => Atom.to_string(assessment.type),
+              "type" => assessment.type,
               "title" => assessment.title
             }
           }

--- a/test/cadet_web/controllers/user_controller_test.exs
+++ b/test/cadet_web/controllers/user_controller_test.exs
@@ -5,7 +5,7 @@ defmodule CadetWeb.UserControllerTest do
 
   alias Cadet.Repo
   alias CadetWeb.UserController
-  alias Cadet.Assessments.{Assessment, AssessmentType, Submission}
+  alias Cadet.Assessments.{Assessment, Submission}
   alias Cadet.Accounts.User
 
   test "swagger" do
@@ -232,11 +232,11 @@ defmodule CadetWeb.UserControllerTest do
 
     defp build_assessments_starting_at(time) do
       type_order_map =
-        AssessmentType.__enum_map__()
+        Assessment.assessment_types()
         |> Enum.with_index()
         |> Enum.reduce(%{}, fn {type, idx}, acc -> Map.put(acc, type, idx) end)
 
-      AssessmentType.__enum_map__()
+      Assessment.assessment_types()
       |> Enum.map(
         &build(:assessment, %{
           type: &1,

--- a/test/factories/assessments/assessment_factory.ex
+++ b/test/factories/assessments/assessment_factory.ex
@@ -8,7 +8,7 @@ defmodule Cadet.Assessments.AssessmentFactory do
       alias Cadet.Assessments.Assessment
 
       def assessment_factory do
-        type = Enum.random([:mission, :sidequest, :contest, :path])
+        type = Enum.random(Assessment.assessment_types() -- ["practical"])
 
         # These are actual story identifiers so front-end can use seeds to test more effectively
         valid_stories = [
@@ -28,7 +28,7 @@ defmodule Cadet.Assessments.AssessmentFactory do
           number:
             sequence(
               :number,
-              &"#{type |> Atom.to_string() |> String.first() |> String.upcase()}#{&1}"
+              &"#{type |> String.first() |> String.upcase()}#{&1}"
             ),
           story: Enum.random(valid_stories),
           reading: Faker.Lorem.sentence(),

--- a/test/support/seeds.ex
+++ b/test/support/seeds.ex
@@ -47,7 +47,7 @@ defmodule Cadet.Test.Seeds do
 
       assessments =
         Enum.reduce(
-          Cadet.Assessments.AssessmentType.__enum_map__(),
+          Cadet.Assessments.Assessment.assessment_types(),
           %{},
           fn type, acc -> Map.put(acc, type, insert_assessments(type, students)) end
         )


### PR DESCRIPTION
## Replace assessment type enum with equivalent string values
Summary: Code quality improvements.

### Changelog
- Replace all use of the Ecto enum `AssessmentType` for an assessment's `:type` with equivalent string values
  - An assessment's `:type` is now of `:string` type
  - The assessment changeset now explicitly validates that `:type` is a string specified in `@assessment_types` (`"contest"`, `"mission"`, `"path"`, `"practical"` and `"sidequest"`)
  - **This introduces a new database migration**
- Remove the Ecto enum `AssessmentType`
  - **This introduces modifications to past database migrations**

Last updated 15 Aug 2020, 4:00PM