### PR TITLE
Update /settings endpoint

### DIFF
--- a/lib/cadet/assessments/library.ex
+++ b/lib/cadet/assessments/library.ex
@@ -1,6 +1,6 @@
 defmodule Cadet.Assessments.Library do
   @moduledoc """
-  The library entity represents a library to be used in a  question.
+  The library entity represents a library to be used in a question.
   """
   use Cadet, :model
 

--- a/lib/cadet_web/admin_controllers/admin_settings_controller.ex
+++ b/lib/cadet_web/admin_controllers/admin_settings_controller.ex
@@ -1,0 +1,71 @@
+defmodule CadetWeb.AdminSettingsController do
+  @moduledoc """
+  Receives authorized requests involving Academy-wide configuration settings.
+  """
+  use CadetWeb, :controller
+
+  use PhoenixSwagger
+
+  alias Cadet.Settings
+
+  @doc """
+  Receives a /settings/sublanguage PUT request with valid attributes.
+
+  Overrides the stored default Source sublanguage of the Playground.
+  """
+  def update(conn, %{"chapter" => chapter, "variant" => variant}) do
+    case Settings.update_sublanguage(chapter, variant) do
+      {:ok, _} ->
+        text(conn, "OK")
+
+      {:error, _} ->
+        conn
+        |> put_status(:bad_request)
+        |> text("Invalid parameter(s)")
+    end
+  end
+
+  def update(conn, _) do
+    send_resp(conn, :bad_request, "Missing parameter(s)")
+  end
+
+  swagger_path :update do
+    put("/admin/settings/sublanguage")
+
+    summary("Updates the default Source sublanguage of the Playground.")
+
+    security([%{JWT: []}])
+
+    consumes("application/json")
+
+    parameters do
+      sublanguage(:body, Schema.ref(:AdminSublanguage), "sublanguage object", required: true)
+    end
+
+    response(200, "OK")
+    response(400, "Missing or invalid parameter(s)")
+    response(403, "Forbidden")
+  end
+
+  def swagger_definitions do
+    %{
+      AdminSublanguage:
+        swagger_schema do
+          title("AdminSublanguage")
+
+          properties do
+            chapter(:integer, "Chapter number from 1 to 4", required: true, minimum: 1, maximum: 4)
+
+            variant(:string, "Variant name, one of default/concurrent/gpu/lazy/non-det/wasm",
+              required: true
+            )
+          end
+
+          example(%{
+            chapter: 2,
+            variant: "lazy"
+          })
+        end
+    }
+  end
+end

--- a/lib/cadet_web/controllers/settings_controller.ex
+++ b/lib/cadet_web/controllers/settings_controller.ex
@@ -1,13 +1,12 @@
 defmodule CadetWeb.SettingsController do
   @moduledoc """
-  Receives all requests involving Academy-wide configuration settings.
+  Receives public requests involving Academy-wide configuration settings.
   """
   use CadetWeb, :controller
+
   use PhoenixSwagger
 
   alias Cadet.Settings
-
-  @set_sublanguage_roles ~w(staff admin)a
 
   @doc """
   Receives a /settings/sublanguage GET request.
@@ -20,35 +19,6 @@ defmodule CadetWeb.SettingsController do
     render(conn, "show.json", sublanguage: sublanguage)
   end
 
-  @doc """
-  Receives a /settings/sublanguage PUT request with valid attributes.
-
-  Overrides the stored default Source sublanguage of the Playground.
-  """
-  def update(conn, %{"chapter" => chapter, "variant" => variant}) do
-    role = conn.assigns[:current_user].role
-
-    if role in @set_sublanguage_roles do
-      case Settings.update_sublanguage(chapter, variant) do
-        {:ok, _} ->
-          text(conn, "OK")
-
-        {:error, _} ->
-          conn
-          |> put_status(:bad_request)
-          |> text("Invalid parameter(s)")
-      end
-    else
-      conn
-      |> put_status(:forbidden)
-      |> text("User not allowed to set default Playground sublanguage.")
-    end
-  end
-
-  def update(conn, _) do
-    send_resp(conn, :bad_request, "Missing parameter(s)")
-  end
-
   swagger_path :index do
     get("/settings/sublanguage")
 
@@ -57,25 +27,6 @@ defmodule CadetWeb.SettingsController do
     produces("application/json")
 
     response(200, "OK", Schema.ref(:Sublanguage))
-  end
-
-  swagger_path :update do
-    put("/settings/sublanguage")
-
-    summary("Updates the default Source sublanguage of the Playground.")
-
-    security([%{JWT: []}])
-
-    consumes("application/json")
-
-    parameters do
-      sublanguage(:body, Schema.ref(:Sublanguage), "sublanguage object", required: true)
-    end
-
-    response(200, "OK")
-    response(400, "Missing or invalid parameter(s)")
-    response(401, "Unauthorised")
-    response(403, "User not allowed to set default Playground sublanguage.")
   end
 
   def swagger_definitions do

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -85,8 +85,6 @@ defmodule CadetWeb.Router do
     post("/devices/:id", DevicesController, :edit)
     delete("/devices/:id", DevicesController, :deregister)
     get("/devices/:id/ws_endpoint", DevicesController, :get_ws_endpoint)
-
-    put("/settings/sublanguage", SettingsController, :update)
   end
 
   # Authenticated Pages
@@ -117,6 +115,8 @@ defmodule CadetWeb.Router do
     get("/assets/:foldername", AdminAssetsController, :index)
     post("/assets/:foldername/*filename", AdminAssetsController, :upload)
     delete("/assets/:foldername/*filename", AdminAssetsController, :delete)
+
+    put("/settings/sublanguage", AdminSettingsController, :update)
   end
 
   # Other scopes may use custom stacks.

--- a/test/cadet_web/admin_controllers/admin_settings_test.exs
+++ b/test/cadet_web/admin_controllers/admin_settings_test.exs
@@ -1,0 +1,59 @@
+defmodule CadetWeb.AdminSettingsControllerTest do
+  use CadetWeb.ConnCase
+
+  alias CadetWeb.AdminSettingsController
+
+  test "swagger" do
+    AdminSettingsController.swagger_definitions()
+    AdminSettingsController.swagger_path_update(nil)
+  end
+
+  describe "PUT /settings/sublanguage" do
+    @tag authenticate: :admin
+    test "succeeds", %{conn: conn} do
+      insert(:sublanguage, %{chapter: 4, variant: "gpu"})
+
+      conn =
+        put(conn, build_url(), %{
+          "chapter" => Enum.random(1..4),
+          "variant" => "default"
+        })
+
+      assert response(conn, 200) == "OK"
+    end
+
+    @tag authenticate: :staff
+    test "succeeds when no default sublanguage entry exists", %{conn: conn} do
+      conn =
+        put(conn, build_url(), %{
+          "chapter" => Enum.random(1..4),
+          "variant" => "default"
+        })
+
+      assert response(conn, 200) == "OK"
+    end
+
+    @tag authenticate: :student
+    test "rejects forbidden request for non-staff users", %{conn: conn} do
+      conn = put(conn, build_url(), %{"chapter" => 3, "variant" => "concurrent"})
+
+      assert response(conn, 403) == "Forbidden"
+    end
+
+    @tag authenticate: :staff
+    test "rejects requests with invalid params", %{conn: conn} do
+      conn = put(conn, build_url(), %{"chapter" => 4, "variant" => "wasm"})
+
+      assert response(conn, 400) == "Invalid parameter(s)"
+    end
+
+    @tag authenticate: :staff
+    test "rejects requests with missing params", %{conn: conn} do
+      conn = put(conn, build_url(), %{"variant" => "default"})
+
+      assert response(conn, 400) == "Missing parameter(s)"
+    end
+  end
+
+  defp build_url, do: "/v2/admin/settings/sublanguage"
+end

--- a/test/cadet_web/controllers/settings_controller_test.exs
+++ b/test/cadet_web/controllers/settings_controller_test.exs
@@ -6,7 +6,6 @@ defmodule CadetWeb.SettingsControllerTest do
   test "swagger" do
     SettingsController.swagger_definitions()
     SettingsController.swagger_path_index(nil)
-    SettingsController.swagger_path_update(nil)
   end
 
   describe "GET /settings/sublanguage" do
@@ -22,53 +21,6 @@ defmodule CadetWeb.SettingsControllerTest do
       resp = conn |> get(build_url()) |> json_response(200)
 
       assert %{"sublanguage" => %{"chapter" => 1, "variant" => "default"}} = resp
-    end
-  end
-
-  describe "PUT /settings/sublanguage" do
-    @tag authenticate: :admin
-    test "succeeds", %{conn: conn} do
-      insert(:sublanguage, %{chapter: 4, variant: "gpu"})
-
-      conn =
-        put(conn, build_url(), %{
-          "chapter" => Enum.random(1..4),
-          "variant" => "default"
-        })
-
-      assert response(conn, 200) == "OK"
-    end
-
-    @tag authenticate: :staff
-    test "succeeds when no default sublanguage entry exists", %{conn: conn} do
-      conn =
-        put(conn, build_url(), %{
-          "chapter" => Enum.random(1..4),
-          "variant" => "default"
-        })
-
-      assert response(conn, 200) == "OK"
-    end
-
-    @tag authenticate: :student
-    test "rejects forbidden request for non-staff users", %{conn: conn} do
-      conn = put(conn, build_url(), %{"chapter" => 3, "variant" => "concurrent"})
-
-      assert response(conn, 403) == "User not allowed to set default Playground sublanguage."
-    end
-
-    @tag authenticate: :staff
-    test "rejects requests with invalid params", %{conn: conn} do
-      conn = put(conn, build_url(), %{"chapter" => 4, "variant" => "wasm"})
-
-      assert response(conn, 400) == "Invalid parameter(s)"
-    end
-
-    @tag authenticate: :staff
-    test "rejects requests with missing params", %{conn: conn} do
-      conn = put(conn, build_url(), %{"variant" => "default"})
-
-      assert response(conn, 400) == "Missing parameter(s)"
     end
   end
 


### PR DESCRIPTION
Shift `PUT /settings/sublanguage` to `PUT /admin/settings/sublanguage`, since the latter is only allowed for authorized users, to align with our v2 API design guidelines.