### PR TITLE
Add Google OpenID claim extractor

### DIFF
--- a/lib/cadet/auth/providers/cognito_claim_extractor.ex
+++ b/lib/cadet/auth/providers/cognito_claim_extractor.ex
@@ -22,4 +22,6 @@ defmodule Cadet.Auth.Providers.CognitoClaimExtractor do
       _ -> :student
     end
   end
+
+  def get_token_type, do: "access_token"
 end

--- a/lib/cadet/auth/providers/google_claim_extractor.ex
+++ b/lib/cadet/auth/providers/google_claim_extractor.ex
@@ -1,0 +1,21 @@
+defmodule Cadet.Auth.Providers.GoogleClaimExtractor do
+  @moduledoc """
+  Extracts fields from Google JWTs.
+  """
+
+  @behaviour Cadet.Auth.Providers.OpenID.ClaimExtractor
+
+  def get_username(claims) do
+    if claims["email_verified"] do
+      claims["email"]
+    else
+      nil
+    end
+  end
+
+  def get_name(_claims), do: nil
+
+  def get_role(_claims), do: nil
+
+  def get_token_type, do: "id_token"
+end

--- a/test/cadet/auth/providers/cognito_claim_extractor_test.exs
+++ b/test/cadet/auth/providers/cognito_claim_extractor_test.exs
@@ -12,5 +12,7 @@ defmodule Cadet.Auth.Providers.CognitoClaimExtractorTest do
     assert @username == Testee.get_name(@claims)
     assert @role == Testee.get_role(@claims)
     assert :admin == Testee.get_role(%{"cognito:groups" => [:admin]})
+
+    assert Testee.get_token_type() == "access_token"
   end
 end

--- a/test/cadet/auth/providers/google_claim_extractor_test.exs
+++ b/test/cadet/auth/providers/google_claim_extractor_test.exs
@@ -1,0 +1,25 @@
+defmodule Cadet.Auth.Providers.GoogleClaimExtractorTest do
+  use ExUnit.Case, async: true
+
+  alias Cadet.Auth.Providers.GoogleClaimExtractor, as: Testee
+
+  @username "hello@world.com"
+
+  test "test verified email" do
+    claims = %{"email" => @username, "email_verified" => true}
+
+    assert Testee.get_username(claims) == @username
+    assert is_nil(Testee.get_name(claims))
+    assert is_nil(Testee.get_role(claims))
+
+    assert Testee.get_token_type() == "id_token"
+  end
+
+  test "test non-verified email" do
+    claims = %{"email" => @username, "email_verified" => false}
+
+    assert is_nil(Testee.get_username(claims))
+    assert is_nil(Testee.get_name(claims))
+    assert is_nil(Testee.get_role(claims))
+  end
+end

--- a/test/cadet/auth/providers/openid_test.exs
+++ b/test/cadet/auth/providers/openid_test.exs
@@ -157,4 +157,15 @@ defmodule Cadet.Auth.Providers.OpenIDTest do
     assert {:error, :invalid_credentials, "Failed to fetch token from OpenID provider"} ==
              OpenID.authorise(@config, "dummy_code", "", "")
   end
+
+  test "missing token", %{bypass: bypass} do
+    Bypass.stub(bypass, "POST", "/oauth2/token", fn conn ->
+      conn
+      |> PlugConn.put_resp_header("content-type", "application/json")
+      |> PlugConn.resp(200, ~s({}))
+    end)
+
+    assert {:error, :invalid_credentials, "Missing token in response from OpenID provider"} ==
+             OpenID.authorise(@config, "dummy_code", "", "")
+  end
 end


### PR DESCRIPTION
This allows using Google as an authentication provider.