### PR TITLE
Fix bug with leaderboard contest_number field not found

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -907,13 +907,13 @@ defmodule Cadet.Assessments do
 
   # Finds the contest_question_id associated with the given voting_question id
   defp fetch_associated_contest_question_id(voting_question) do
-    number = voting_question.question["contest_number"]
+    contest_number = voting_question.question["contest_number"]
 
-    if is_nil(number) do
+    if is_nil(contest_number) do
       nil
     else
       Assessment
-      |> where(number: ^number)
+      |> where(number: ^contest_number)
       |> join(:inner, [a], q in assoc(a, :questions))
       |> order_by([a, q], q.display_order)
       |> select([a, q], q.id)

--- a/lib/cadet/assessments/question_types/voting_question.ex
+++ b/lib/cadet/assessments/question_types/voting_question.ex
@@ -9,9 +9,10 @@ defmodule Cadet.Assessments.QuestionTypes.VotingQuestion do
     field(:content, :string)
     field(:prepend, :string, default: "")
     field(:template, :string)
+    field(:contest_number, :string)
   end
 
-  @required_fields ~w(content)a
+  @required_fields ~w(content contest_number)a
   @optional_fields ~w(prepend template)a
 
   def changeset(question, params \\ %{}) do

--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -71,7 +71,8 @@ defmodule Cadet.AssessmentsTest do
           type: :voting,
           library: build(:library),
           question: %{
-            content: Faker.Pokemon.name()
+            content: Faker.Pokemon.name(),
+            contest_number: assessment.number
           }
         },
         assessment.id

--- a/test/cadet/assessments/question_test.exs
+++ b/test/cadet/assessments/question_test.exs
@@ -37,7 +37,8 @@ defmodule Cadet.Assessments.QuestionTest do
       assessment_id: assessment.id,
       library: build(:library),
       question: %{
-        content: Faker.Pokemon.name()
+        content: Faker.Pokemon.name(),
+        contest_number: assessment.number
       }
     }
 

--- a/test/cadet/assessments/question_types/voting_question_test.exs
+++ b/test/cadet/assessments/question_types/voting_question_test.exs
@@ -7,7 +7,8 @@ defmodule Cadet.Assessments.QuestionTypes.VotingQuestionTest do
     test "valid changeset" do
       assert_changeset(
         %{
-          content: "asd"
+          content: "content",
+          contest_number: "C4"
         },
         :valid
       )


### PR DESCRIPTION
Fix a bug with the contest_number being null when loading contest entries 