### PR TITLE
Add assessment level language and evaluator config fields

### DIFF
--- a/lib/cadet/assessments/assessment.ex
+++ b/lib/cadet/assessments/assessment.ex
@@ -38,6 +38,8 @@ defmodule Cadet.Assessments.Assessment do
     field(:has_voting_features, :boolean, default: false)
     field(:llm_assessment_prompt, :string, default: nil)
     field(:is_autosave_enabled, :boolean, default: true)
+    field(:language_id, :string, default: nil)
+    field(:evaluator_id, :string, default: nil)
 
     belongs_to(:config, AssessmentConfig)
     belongs_to(:course, Course)
@@ -48,7 +50,7 @@ defmodule Cadet.Assessments.Assessment do
 
   @required_fields ~w(title open_at close_at number course_id config_id max_team_size)a
   @optional_fields ~w(reading summary_short summary_long
-    is_published story cover_picture access password has_token_counter has_voting_features llm_assessment_prompt is_autosave_enabled)a
+    is_published story cover_picture access password has_token_counter has_voting_features llm_assessment_prompt is_autosave_enabled language_id evaluator_id)a
   @optional_file_fields ~w(mission_pdf)a
 
   def changeset(assessment, params) do

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -100,7 +100,8 @@ defmodule Cadet.Updater.XMLParser do
         summary_long: ~x"./TEXT/text()" |> transform_by(&process_charlist/1),
         llm_assessment_prompt:
           ~x"./LLM_ASSESSMENT_PROMPT/text()" |> transform_by(&process_charlist/1),
-        password: ~x"//PASSWORD/text()"so |> transform_by(&process_charlist/1)
+        password: ~x"//PASSWORD/text()"so |> transform_by(&process_charlist/1),
+        deployment_interpreter: ~x"./DEPLOYMENT/@interpreter"oi
       )
       |> Map.put(:is_published, false)
       |> Map.put(:open_at, open_at)
@@ -110,6 +111,7 @@ defmodule Cadet.Updater.XMLParser do
       |> Map.put(:has_token_counter, assessment_config.has_token_counter)
       |> Map.put(:has_voting_features, assessment_config.has_voting_features)
       |> Map.put(:is_autosave_enabled, assessment_config.is_autosave_enabled)
+      |> put_conductor_language_config()
       |> (&if(&1.access === "public",
             do: Map.put(&1, :password, nil),
             else: &1
@@ -126,6 +128,20 @@ defmodule Cadet.Updater.XMLParser do
       {:error, "Missing TASK"}
   end
 
+  # The <DEPLOYMENT interpreter="N"/> tag names a Python sub-chapter (1-4). There's no per-tag
+  # evaluator choice: DEPLOYMENT-tagged assessments always deploy on the Py2JS transpiler.
+  @spec put_conductor_language_config(map()) :: map()
+  defp put_conductor_language_config(%{deployment_interpreter: nil} = params) do
+    Map.delete(params, :deployment_interpreter)
+  end
+
+  defp put_conductor_language_config(%{deployment_interpreter: n} = params) do
+    params
+    |> Map.delete(:deployment_interpreter)
+    |> Map.put(:language_id, "python#{n}")
+    |> Map.put(:evaluator_id, "python#{n}Py2js")
+  end
+
   def process_access("private") do
     "private"
   end
@@ -136,7 +152,12 @@ defmodule Cadet.Updater.XMLParser do
 
   @spec process_questions(String.t()) :: {:ok, [map()]} | {:error, String.t()}
   defp process_questions(xml) do
-    default_library = xpath(xml, ~x"//TASK/PROGRAMMINGLANGUAGE"e)
+    # <DEPLOYMENT interpreter="N"/> shares PROGRAMMINGLANGUAGE's @interpreter attribute shape, so it
+    # can stand in as the default library when a Conductor-only assessment omits PROGRAMMINGLANGUAGE
+    # entirely (e.g. a Python-only mission with no js-slang question variant).
+    default_library =
+      xpath(xml, ~x"//TASK/PROGRAMMINGLANGUAGE"e) || xpath(xml, ~x"//TASK/DEPLOYMENT"e)
+
     default_grading_library = xpath(xml, ~x"//TASK/GRADERPROGRAMMINGLANGUAGE"e)
 
     questions_params =

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -131,11 +131,11 @@ defmodule Cadet.Updater.XMLParser do
   # The <DEPLOYMENT interpreter="N"/> tag names a Python sub-chapter (1-4). There's no per-tag
   # evaluator choice: DEPLOYMENT-tagged assessments always deploy on the Py2JS transpiler.
   @spec put_conductor_language_config(map()) :: map()
-  defp put_conductor_language_config(%{deployment_interpreter: nil} = params) do
+  defp put_conductor_language_config(params = %{deployment_interpreter: nil}) do
     Map.delete(params, :deployment_interpreter)
   end
 
-  defp put_conductor_language_config(%{deployment_interpreter: n} = params) do
+  defp put_conductor_language_config(params = %{deployment_interpreter: n}) do
     params
     |> Map.delete(:deployment_interpreter)
     |> Map.put(:language_id, "python#{n}")

--- a/lib/cadet_web/admin_controllers/admin_assessments_controller.ex
+++ b/lib/cadet_web/admin_controllers/admin_assessments_controller.ex
@@ -88,6 +88,8 @@ defmodule CadetWeb.AdminAssessmentsController do
     has_voting_features = params |> Map.get("hasVotingFeatures")
     is_autosave_enabled = params |> Map.get("isAutosaveEnabled")
     assign_entries_for_voting = params |> Map.get("assignEntriesForVoting")
+    language_id = params |> Map.get("languageId")
+    evaluator_id = params |> Map.get("evaluatorId")
 
     updated_assessment =
       if is_nil(is_published) do
@@ -122,6 +124,20 @@ defmodule CadetWeb.AdminAssessmentsController do
         updated_assessment
       else
         Map.put(updated_assessment, :is_autosave_enabled, is_autosave_enabled)
+      end
+
+    updated_assessment =
+      if is_nil(language_id) do
+        updated_assessment
+      else
+        Map.put(updated_assessment, :language_id, language_id)
+      end
+
+    updated_assessment =
+      if is_nil(evaluator_id) do
+        updated_assessment
+      else
+        Map.put(updated_assessment, :evaluator_id, evaluator_id)
       end
 
     is_reassigning_voting =
@@ -312,6 +328,14 @@ defmodule CadetWeb.AdminAssessmentsController do
             openAt(:string, "Close date", required: false)
             isPublished(:boolean, "Whether the assessment is published", required: false)
             maxTeamSize(:number, "Max team size of the assessment", required: false)
+
+            languageId(:string, "Language directory id for the assessment's evaluator",
+              required: false
+            )
+
+            evaluatorId(:string, "Evaluator id within the language for the assessment",
+              required: false
+            )
           end
         end
     }

--- a/lib/cadet_web/admin_controllers/admin_assessments_controller.ex
+++ b/lib/cadet_web/admin_controllers/admin_assessments_controller.ex
@@ -127,17 +127,17 @@ defmodule CadetWeb.AdminAssessmentsController do
       end
 
     updated_assessment =
-      if is_nil(language_id) do
-        updated_assessment
-      else
+      if Map.has_key?(params, "languageId") do
         Map.put(updated_assessment, :language_id, language_id)
+      else
+        updated_assessment
       end
 
     updated_assessment =
-      if is_nil(evaluator_id) do
-        updated_assessment
-      else
+      if Map.has_key?(params, "evaluatorId") do
         Map.put(updated_assessment, :evaluator_id, evaluator_id)
+      else
+        updated_assessment
       end
 
     is_reassigning_voting =

--- a/lib/cadet_web/admin_views/admin_assessments_view.ex
+++ b/lib/cadet_web/admin_views/admin_assessments_view.ex
@@ -32,7 +32,9 @@ defmodule CadetWeb.AdminAssessmentsView do
       maxTeamSize: :max_team_size,
       hasVotingFeatures: :has_voting_features,
       hasTokenCounter: :has_token_counter,
-      isVotingPublished: :is_voting_published
+      isVotingPublished: :is_voting_published,
+      languageId: :language_id,
+      evaluatorId: :evaluator_id
     })
   end
 
@@ -50,6 +52,8 @@ defmodule CadetWeb.AdminAssessmentsView do
         longSummary: :summary_long,
         hasTokenCounter: :has_token_counter,
         missionPDF: &Cadet.Assessments.Upload.url({&1.mission_pdf, &1}),
+        languageId: :language_id,
+        evaluatorId: :evaluator_id,
         questions:
           &Enum.map(&1.questions, fn question ->
             map =

--- a/lib/cadet_web/views/assessments_view.ex
+++ b/lib/cadet_web/views/assessments_view.ex
@@ -36,7 +36,9 @@ defmodule CadetWeb.AssessmentsView do
       hasTokenCounter: :has_token_counter,
       isVotingPublished: :is_voting_published,
       hoursBeforeEarlyXpDecay: & &1.config.hours_before_early_xp_decay,
-      isAutosaveEnabled: :is_autosave_enabled
+      isAutosaveEnabled: :is_autosave_enabled,
+      languageId: :language_id,
+      evaluatorId: :evaluator_id
     })
   end
 
@@ -56,6 +58,8 @@ defmodule CadetWeb.AssessmentsView do
         missionPDF: &Cadet.Assessments.Upload.url({&1.mission_pdf, &1}),
         isMinigame: & &1.config.is_minigame,
         isAutosaveEnabled: :is_autosave_enabled,
+        languageId: :language_id,
+        evaluatorId: :evaluator_id,
         questions:
           &Enum.map(&1.questions, fn question ->
             map =

--- a/priv/repo/migrations/20260725100000_add_language_config_to_assessment.exs
+++ b/priv/repo/migrations/20260725100000_add_language_config_to_assessment.exs
@@ -1,0 +1,17 @@
+defmodule Cadet.Repo.Migrations.AddLanguageConfigToAssessment do
+  use Ecto.Migration
+
+  def up do
+    alter table(:assessments) do
+      add(:language_id, :string, default: nil)
+      add(:evaluator_id, :string, default: nil)
+    end
+  end
+
+  def down do
+    alter table(:assessments) do
+      remove(:language_id)
+      remove(:evaluator_id)
+    end
+  end
+end

--- a/test/cadet_web/admin_controllers/admin_assessments_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_assessments_controller_test.exs
@@ -94,7 +94,9 @@ defmodule CadetWeb.AdminAssessmentsControllerTest do
             "earlySubmissionXp" => &1.config.early_submission_xp,
             "hasVotingFeatures" => &1.has_voting_features,
             "hasTokenCounter" => &1.has_token_counter,
-            "isVotingPublished" => false
+            "isVotingPublished" => false,
+            "languageId" => &1.language_id,
+            "evaluatorId" => &1.evaluator_id
           }
         )
 
@@ -145,7 +147,9 @@ defmodule CadetWeb.AdminAssessmentsControllerTest do
             "earlySubmissionXp" => &1.config.early_submission_xp,
             "hasVotingFeatures" => &1.has_voting_features,
             "hasTokenCounter" => &1.has_token_counter,
-            "isVotingPublished" => false
+            "isVotingPublished" => false,
+            "languageId" => &1.language_id,
+            "evaluatorId" => &1.evaluator_id
           }
         )
 

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -85,7 +85,9 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "hasTokenCounter" => &1.has_token_counter,
               "isVotingPublished" => false,
               "hoursBeforeEarlyXpDecay" => &1.config.hours_before_early_xp_decay,
-              "isAutosaveEnabled" => &1.is_autosave_enabled
+              "isAutosaveEnabled" => &1.is_autosave_enabled,
+              "languageId" => &1.language_id,
+              "evaluatorId" => &1.evaluator_id
             }
           )
 
@@ -177,7 +179,9 @@ defmodule CadetWeb.AssessmentsControllerTest do
             "hasTokenCounter" => &1.has_token_counter,
             "isVotingPublished" => false,
             "hoursBeforeEarlyXpDecay" => &1.config.hours_before_early_xp_decay,
-            "isAutosaveEnabled" => true
+            "isAutosaveEnabled" => true,
+            "languageId" => &1.language_id,
+            "evaluatorId" => &1.evaluator_id
           }
         )
 
@@ -295,6 +299,8 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "isGradingPublished" => nil,
               "hoursBeforeEarlyXpDecay" => &1.config.hours_before_early_xp_decay,
               "isAutosaveEnabled" => &1.is_autosave_enabled,
+              "languageId" => &1.language_id,
+              "evaluatorId" => &1.evaluator_id,
               "isPublished" =>
                 if &1.config.type == hd(configs).type do
                   false
@@ -332,7 +338,9 @@ defmodule CadetWeb.AssessmentsControllerTest do
             "hasTokenCounter" => assessment.has_token_counter,
             "missionPDF" => Cadet.Assessments.Upload.url({assessment.mission_pdf, assessment}),
             "isMinigame" => false,
-            "isAutosaveEnabled" => true
+            "isAutosaveEnabled" => true,
+            "languageId" => assessment.language_id,
+            "evaluatorId" => assessment.evaluator_id
           }
 
           resp_assessments =


### PR DESCRIPTION
## Summary

Adds nullable language_id and evaluator_id columns on assessments so that a mission, quest, path or contest can be configured with a Conductor backed language (e.g. Python), instead of relying only on the global Playground language selector. This mirrors the frontend WIP in source-academy/frontend#4057, which handles the Run and testcase grading paths for Conductor languages but currently has no way to know which language a given assessment should use.

Scope, following the direction agreed with Prof Henz: assessment level config only, not per question. The existing Library.chapter/variant fields on questions are untouched.

## Changes

- New migration adding language_id and evaluator_id (both nullable strings, default nil) to the assessments table. Existing assessments are unaffected and keep current js-slang behaviour until a value is set.
- Assessment schema and changeset updated to accept the two new optional fields.
- Admin update endpoint accepts languageId and evaluatorId in the update payload, following the same pattern as existing optional fields like hasTokenCounter.
- Both the student facing and admin facing assessment views serialise the new fields in the overview and show responses.
- Updated existing controller tests that assert exact response bodies to include the new keys.

## Test plan

- [x] mix format
- [x] mix compile with no new warnings
- [x] mix test (assessment related suites run individually, then full suite via pre push hook)
- [ ] Manual verification once the frontend side is wired up to actually set and read these fields for a Python assessment