### PR TITLE
Add support for conductor assessments

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -94,7 +94,7 @@
         {Credo.Check.Readability.SpaceAfterCommas},
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.CondStatements},
-        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 11},
+        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 16},
         {Credo.Check.Refactor.FunctionArity},
         {Credo.Check.Refactor.LongQuoteBlocks},
         {Credo.Check.Refactor.MatchInCondition},

--- a/.credo.exs
+++ b/.credo.exs
@@ -94,7 +94,7 @@
         {Credo.Check.Readability.SpaceAfterCommas},
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.CondStatements},
-        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 16},
+        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 11},
         {Credo.Check.Refactor.FunctionArity},
         {Credo.Check.Refactor.LongQuoteBlocks},
         {Credo.Check.Refactor.MatchInCondition},

--- a/lib/cadet/assessments/library.ex
+++ b/lib/cadet/assessments/library.ex
@@ -67,7 +67,8 @@ defmodule Cadet.Assessments.Library do
   defp validate_conductor_no_legacy_fields(changeset) do
     forbidden = [:chapter, :variant, :exec_time_ms, :globals, :language_options]
 
-    Enum.reduce(forbidden, changeset, fn field, acc ->
+    forbidden
+    |> Enum.reduce(changeset, fn field, acc ->
       case fetch_change(acc, field) do
         {:ok, _value} ->
           add_error(acc, field, "must not be set for conductor format")

--- a/lib/cadet/assessments/library.ex
+++ b/lib/cadet/assessments/library.ex
@@ -1,6 +1,19 @@
 defmodule Cadet.Assessments.Library do
   @moduledoc """
   The library entity represents a library to be used in a question.
+
+  Two formats are supported, distinguished by the `format` field:
+
+    * `:legacy` (default) — the original Source-dialect library specified
+      via `chapter` (from `@interpreter`), `variant`, `exec_time_ms`,
+      `globals`, `language_options` and an embedded `external` library.
+
+    * `:conductor` — a language-agnostic tuple of `(language, evaluator)`
+      string IDs that are resolved by an external runtime. Legacy fields
+      must NOT be present.
+
+  See `Cadet.Updater.XMLParser` for the XML rule that determines which
+  format a given `PROGRAMMINGLANGUAGE` element produces.
   """
   use Cadet, :model
 
@@ -8,27 +21,92 @@ defmodule Cadet.Assessments.Library do
 
   @primary_key false
   embedded_schema do
+    field(:format, Ecto.Enum, values: [:legacy, :conductor], default: :legacy)
     field(:chapter, :integer, default: 1)
     field(:variant, :string, default: nil)
     field(:exec_time_ms, :integer, default: 1000)
     field(:globals, :map, default: %{})
     field(:language_options, :map, default: %{})
+    field(:language, :string, default: nil)
+    field(:evaluator, :string, default: nil)
     embeds_one(:external, ExternalLibrary, on_replace: :update)
   end
 
-  @required_fields ~w(chapter)a
-  @optional_fields ~w(globals variant language_options exec_time_ms)a
-  @required_embeds ~w(external)a
+  @required_fields ~w()a
+  @optional_fields ~w(format globals variant language_options exec_time_ms language evaluator chapter)a
 
   def changeset(library, params \\ %{}) do
     library
     |> cast(params, @required_fields ++ @optional_fields)
     |> cast_embed(:external)
     |> put_default_external()
-    |> validate_required(@required_fields ++ @required_embeds)
+    |> validate_library_format()
     |> validate_globals()
     |> validate_chapter()
     |> validate_chapter_variant()
+  end
+
+  defp validate_library_format(changeset) do
+    format = get_field(changeset, :format)
+
+    case format do
+      :conductor ->
+        validate_conductor_format(changeset)
+
+      _ ->
+        validate_legacy_format(changeset)
+    end
+  end
+
+  defp validate_conductor_format(changeset) do
+    changeset
+    |> validate_required([:language, :evaluator])
+    |> validate_conductor_no_legacy_fields()
+  end
+
+  defp validate_conductor_no_legacy_fields(changeset) do
+    forbidden = [:chapter, :variant, :exec_time_ms, :globals, :language_options]
+
+    Enum.reduce(forbidden, changeset, fn field, acc ->
+      case fetch_change(acc, field) do
+        {:ok, _value} ->
+          add_error(acc, field, "must not be set for conductor format")
+
+        :error ->
+          acc
+      end
+    end)
+    |> validate_conductor_no_external()
+  end
+
+  defp validate_conductor_no_external(changeset) do
+    case fetch_change(changeset, :external) do
+      {:ok, %ExternalLibrary{name: "none", symbols: []}} ->
+        changeset
+
+      {:ok, _} ->
+        add_error(changeset, :external, "must not be set for conductor format")
+
+      :error ->
+        changeset
+    end
+  end
+
+  defp validate_legacy_format(changeset) do
+    changeset
+    |> forbid_conductor_field(:language)
+    |> forbid_conductor_field(:evaluator)
+    |> validate_required([:chapter, :external])
+  end
+
+  defp forbid_conductor_field(changeset, field) do
+    case fetch_change(changeset, field) do
+      {:ok, value} when not is_nil(value) ->
+        add_error(changeset, field, "must not be set for legacy format")
+
+      _ ->
+        changeset
+    end
   end
 
   defp validate_globals(changeset) do
@@ -46,10 +124,14 @@ defmodule Cadet.Assessments.Library do
   end
 
   defp validate_chapter(changeset) do
-    case changeset |> fetch_change(:chapter) do
-      {:ok, c} when c in 1..4 -> changeset
-      :error -> changeset
-      _ -> add_error(changeset, :chapter, "invalid chapter")
+    if get_field(changeset, :format) == :conductor do
+      changeset
+    else
+      case changeset |> fetch_change(:chapter) do
+        {:ok, c} when c in 1..4 -> changeset
+        :error -> changeset
+        _ -> add_error(changeset, :chapter, "invalid chapter")
+      end
     end
   end
 
@@ -70,6 +152,14 @@ defmodule Cadet.Assessments.Library do
   ]
 
   defp validate_chapter_variant(changeset) do
+    if get_field(changeset, :format) == :conductor do
+      changeset
+    else
+      do_validate_chapter_variant(changeset)
+    end
+  end
+
+  defp do_validate_chapter_variant(changeset) do
     chapter = changeset |> fetch_field(:chapter)
     variant = changeset |> fetch_field(:variant)
 
@@ -92,12 +182,18 @@ defmodule Cadet.Assessments.Library do
   end
 
   def put_default_external(changeset) do
+    format = get_field(changeset, :format)
     external = get_change(changeset, :external)
 
-    if external do
-      changeset
-    else
-      put_change(changeset, :external, %{})
+    cond do
+      format == :conductor and is_nil(external) ->
+        changeset
+
+      external ->
+        changeset
+
+      true ->
+        put_change(changeset, :external, %{})
     end
   end
 end

--- a/lib/cadet/jobs/autograder/lambda_worker.ex
+++ b/lib/cadet/jobs/autograder/lambda_worker.ex
@@ -126,8 +126,28 @@ defmodule Cadet.Autograder.LambdaWorker do
   def build_request_params(%{question: question = %Question{}, answer: answer = %Answer{}}) do
     question_content = question.question
 
+    cond do
+      # Conductor libraries must not be evaluated by the legacy Source-based
+      # lambda. A future conductor autograder pipeline is expected to take
+      # over; until then we explicitly refuse to grade so the caller can
+      # surface a clear error rather than crashing.
+      question.grading_library.format == :conductor ->
+        raise __MODULE__.UnsupportedGradingFormatError,
+          message:
+            "Conductor libraries (language/evaluator) are not supported by the legacy lambda autograder."
+
+      is_nil(question.grading_library.external) ->
+        raise ArgumentError,
+          message: "Question #{question.id} has no external library; cannot autograde."
+
+      true ->
+        do_build_request_params(question_content, question.grading_library, answer)
+    end
+  end
+
+  defp do_build_request_params(question_content, grading_library, answer) do
     {_, upcased_name_external} =
-      question.grading_library.external
+      grading_library.external
       |> Map.from_struct()
       |> Map.get_and_update(
         :name,
@@ -142,11 +162,15 @@ defmodule Cadet.Autograder.LambdaWorker do
         Map.get(question_content, "public", []) ++
           Map.get(question_content, "opaque", []) ++ Map.get(question_content, "secret", []),
       library: %{
-        chapter: question.grading_library.chapter,
+        chapter: grading_library.chapter,
         external: upcased_name_external,
-        globals: Enum.map(question.grading_library.globals, fn {k, v} -> [k, v] end)
+        globals: Enum.map(grading_library.globals, fn {k, v} -> [k, v] end)
       }
     }
+  end
+
+  defmodule UnsupportedGradingFormatError do
+    defexception [:message]
   end
 
   defp parse_response(response) when is_map(response) do

--- a/lib/cadet/jobs/autograder/lambda_worker.ex
+++ b/lib/cadet/jobs/autograder/lambda_worker.ex
@@ -125,23 +125,21 @@ defmodule Cadet.Autograder.LambdaWorker do
 
   def build_request_params(%{question: question = %Question{}, answer: answer = %Answer{}}) do
     question_content = question.question
+    grading_library = question.grading_library
 
     cond do
-      # Conductor libraries must not be evaluated by the legacy Source-based
-      # lambda. A future conductor autograder pipeline is expected to take
-      # over; until then we explicitly refuse to grade so the caller can
-      # surface a clear error rather than crashing.
-      question.grading_library.format == :conductor ->
-        raise __MODULE__.UnsupportedGradingFormatError,
-          message:
-            "Conductor libraries (language/evaluator) are not supported by the legacy lambda autograder."
+      # Conductor libraries carry a (language, evaluator) pair that the grader
+      # resolves to an external runtime. The rest of the request (programs and
+      # testcases) is identical to the legacy case.
+      grading_library.format == :conductor ->
+        do_build_conductor_request_params(question_content, grading_library, answer)
 
-      is_nil(question.grading_library.external) ->
+      is_nil(grading_library.external) ->
         raise ArgumentError,
           message: "Question #{question.id} has no external library; cannot autograde."
 
       true ->
-        do_build_request_params(question_content, question.grading_library, answer)
+        do_build_request_params(question_content, grading_library, answer)
     end
   end
 
@@ -154,23 +152,34 @@ defmodule Cadet.Autograder.LambdaWorker do
         &{&1, &1 |> String.upcase()}
       )
 
+    question_content
+    |> base_request_params(answer)
+    |> Map.put(:library, %{
+      chapter: grading_library.chapter,
+      external: upcased_name_external,
+      globals: Enum.map(grading_library.globals, fn {k, v} -> [k, v] end)
+    })
+  end
+
+  defp do_build_conductor_request_params(question_content, grading_library, answer) do
+    question_content
+    |> base_request_params(answer)
+    |> Map.put(:library, %{
+      format: "conductor",
+      language: grading_library.language,
+      evaluator: grading_library.evaluator
+    })
+  end
+
+  defp base_request_params(question_content, answer) do
     %{
       prependProgram: Map.get(question_content, "prepend", ""),
       studentProgram: Map.get(answer.answer, "code"),
       postpendProgram: Map.get(question_content, "postpend", ""),
       testcases:
         Map.get(question_content, "public", []) ++
-          Map.get(question_content, "opaque", []) ++ Map.get(question_content, "secret", []),
-      library: %{
-        chapter: grading_library.chapter,
-        external: upcased_name_external,
-        globals: Enum.map(grading_library.globals, fn {k, v} -> [k, v] end)
-      }
+          Map.get(question_content, "opaque", []) ++ Map.get(question_content, "secret", [])
     }
-  end
-
-  defmodule UnsupportedGradingFormatError do
-    defexception [:message]
   end
 
   defp parse_response(response) when is_map(response) do

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -347,35 +347,55 @@ defmodule Cadet.Updater.XMLParser do
   defp coerce_string(charlist) when is_list(charlist), do: to_string(charlist)
   defp coerce_string(value) when is_binary(value), do: value
 
+  # The presence of a `language` attribute selects the format: conductor when
+  # present, legacy otherwise. Validating each mode separately keeps the
+  # compound conditions (and thus cyclomatic complexity) low.
   defp validate_programming_language_element(attrs, library_entity) do
-    has_external = not is_nil(xpath(library_entity, ~x"./EXTERNAL"o))
-    has_globals = child_list_nonempty?(library_entity, ~x"./GLOBAL"l)
-    has_options = child_list_nonempty?(library_entity, ~x"./OPTION"el)
-    has_children? = has_external or has_globals or has_options
+    if blank?(attrs[:language]) do
+      validate_legacy_programming_language(attrs)
+    else
+      validate_conductor_programming_language(attrs, library_entity)
+    end
+  end
 
+  defp validate_legacy_programming_language(attrs) do
     cond do
-      not blank?(attrs[:language]) and blank?(attrs[:evaluator]) ->
+      not blank?(attrs[:evaluator]) ->
         {:error, "Both 'language' and 'evaluator' must be present, or neither"}
 
-      blank?(attrs[:language]) and not blank?(attrs[:evaluator]) ->
-        {:error, "Both 'language' and 'evaluator' must be present, or neither"}
-
-      not blank?(attrs[:language]) and not is_nil(attrs[:interpreter]) ->
-        {:error,
-         "Cannot mix 'language'/'evaluator' with 'interpreter' on a single PROGRAMMINGLANGUAGE element"}
-
-      not blank?(attrs[:language]) and
-          (not blank?(attrs[:variant]) or not is_nil(attrs[:exectime]) or has_children?) ->
-        {:error,
-         "Conductor PROGRAMMINGLANGUAGE must not have variant/exectime or any child elements"}
-
-      blank?(attrs[:language]) and is_nil(attrs[:interpreter]) ->
+      is_nil(attrs[:interpreter]) ->
         {:error,
          "PROGRAMMINGLANGUAGE element must specify either interpreter or language+evaluator"}
 
       true ->
         :ok
     end
+  end
+
+  defp validate_conductor_programming_language(attrs, library_entity) do
+    cond do
+      blank?(attrs[:evaluator]) ->
+        {:error, "Both 'language' and 'evaluator' must be present, or neither"}
+
+      not is_nil(attrs[:interpreter]) ->
+        {:error,
+         "Cannot mix 'language'/'evaluator' with 'interpreter' on a single PROGRAMMINGLANGUAGE element"}
+
+      conductor_has_disallowed_content?(attrs, library_entity) ->
+        {:error,
+         "Conductor PROGRAMMINGLANGUAGE must not have variant/exectime or any child elements"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp conductor_has_disallowed_content?(attrs, library_entity) do
+    not blank?(attrs[:variant]) or
+      not is_nil(attrs[:exectime]) or
+      not is_nil(xpath(library_entity, ~x"./EXTERNAL"o)) or
+      child_list_nonempty?(library_entity, ~x"./GLOBAL"l) or
+      child_list_nonempty?(library_entity, ~x"./OPTION"el)
   end
 
   defp blank?(nil), do: true

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -62,9 +62,21 @@ defmodule Cadet.Updater.XMLParser do
 
   defp extract_changeset_error_message(errors_list) do
     errors_list
-    |> Enum.map(fn {field, {error, _}} -> "#{to_string(field)} #{error}" end)
-    |> List.foldr("", fn x, acc -> "#{acc <> x} " end)
+    |> Enum.map(fn {field, messages} ->
+      formatted =
+        messages
+        |> List.wrap()
+        |> Enum.map_join(" ", &stringify_error_message/1)
+
+      "#{to_string(field)} #{formatted}"
+    end)
+    |> Enum.join(" ")
   end
+
+  defp stringify_error_message(msg) when is_binary(msg), do: msg
+  defp stringify_error_message({msg, _opts}) when is_binary(msg), do: msg
+  defp stringify_error_message(%Ecto.Changeset{}), do: "embed invalid"
+  defp stringify_error_message(other), do: inspect(other)
 
   @spec process_assessment(String.t(), integer(), integer()) ::
           {:ok, map()} | {:error, String.t()}
@@ -287,16 +299,95 @@ defmodule Cadet.Updater.XMLParser do
         library
 
     if library do
-      question
-      |> Map.put(:library, parse_programming_language(library))
-      |> Map.put(:grading_library, parse_programming_language(grading_library))
+      with {:ok, library_attrs} <- parse_programming_language(library),
+           {:ok, grading_library_attrs} <- parse_programming_language(grading_library) do
+        question
+        |> Map.put(:library, library_attrs)
+        |> Map.put(:grading_library, grading_library_attrs)
+      end
     else
       {:error, "Missing PROGRAMMINGLANGUAGE"}
     end
   end
 
-  @spec parse_programming_language(any()) :: map()
+  @spec parse_programming_language(any()) :: {:ok, map()} | {:error, String.t()}
   defp parse_programming_language(library_entity) do
+    attrs = read_programming_language_attrs(library_entity)
+
+    with :ok <- validate_programming_language_element(attrs, library_entity) do
+      if blank?(attrs[:language]) do
+        {:ok, build_legacy_programming_language_map(library_entity)}
+      else
+        {:ok,
+         %{
+           format: :conductor,
+           language: attrs[:language],
+           evaluator: attrs[:evaluator]
+         }}
+      end
+    end
+  end
+
+  defp read_programming_language_attrs(library_entity) do
+    xpath(
+      library_entity,
+      ~x"."e,
+      interpreter: ~x"./@interpreter"oi,
+      language: ~x"./@language"o |> transform_by(&coerce_string/1),
+      evaluator: ~x"./@evaluator"o |> transform_by(&coerce_string/1),
+      variant: ~x"./@variant"o |> transform_by(&coerce_string/1),
+      exectime: ~x"./@exectime"oi
+    )
+  end
+
+  defp coerce_string(nil), do: nil
+  defp coerce_string(""), do: nil
+  defp coerce_string(charlist) when is_list(charlist), do: to_string(charlist)
+  defp coerce_string(value) when is_binary(value), do: value
+
+  defp validate_programming_language_element(attrs, library_entity) do
+    has_external = not is_nil(xpath(library_entity, ~x"./EXTERNAL"o))
+    has_globals = child_list_nonempty?(library_entity, ~x"./GLOBAL"l)
+    has_options = child_list_nonempty?(library_entity, ~x"./OPTION"el)
+    has_children? = has_external or has_globals or has_options
+
+    cond do
+      not blank?(attrs[:language]) and blank?(attrs[:evaluator]) ->
+        {:error, "Both 'language' and 'evaluator' must be present, or neither"}
+
+      blank?(attrs[:language]) and not blank?(attrs[:evaluator]) ->
+        {:error, "Both 'language' and 'evaluator' must be present, or neither"}
+
+      not blank?(attrs[:language]) and not is_nil(attrs[:interpreter]) ->
+        {:error,
+         "Cannot mix 'language'/'evaluator' with 'interpreter' on a single PROGRAMMINGLANGUAGE element"}
+
+      not blank?(attrs[:language]) and
+          (not blank?(attrs[:variant]) or not is_nil(attrs[:exectime]) or has_children?) ->
+        {:error,
+         "Conductor PROGRAMMINGLANGUAGE must not have variant/exectime or any child elements"}
+
+      blank?(attrs[:language]) and is_nil(attrs[:interpreter]) ->
+        {:error,
+         "PROGRAMMINGLANGUAGE element must specify either interpreter or language+evaluator"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(_), do: false
+
+  defp child_list_nonempty?(library_entity, spec) do
+    case xpath(library_entity, spec) do
+      list when is_list(list) -> list != []
+      _ -> false
+    end
+  end
+
+  defp build_legacy_programming_language_map(library_entity) do
     globals =
       library_entity
       |> xpath(
@@ -323,13 +414,17 @@ defmodule Cadet.Updater.XMLParser do
     options_map =
       options_list |> Map.new(&{&1.key, &1.value})
 
-    library_entity
-    |> xpath(
-      ~x"."e,
-      chapter: ~x"./@interpreter"i,
-      exec_time_ms: ~x"./@exectime"oi,
-      variant: ~x"./@variant"os
-    )
+    base =
+      xpath(
+        library_entity,
+        ~x"."e,
+        chapter: ~x"./@interpreter"i,
+        exec_time_ms: ~x"./@exectime"oi,
+        variant: ~x"./@variant"os
+      )
+
+    base
+    |> Map.put(:format, :legacy)
     |> Map.put(:globals, globals)
     |> Map.put(:external, external)
     |> Map.put(:language_options, options_map)

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -63,6 +63,7 @@ defmodule Cadet.Updater.XMLParser do
   defp extract_changeset_error_message(errors_list) do
     errors_list
     |> Enum.map_join(
+      " ",
       fn {field, messages} ->
         formatted =
           messages
@@ -70,8 +71,7 @@ defmodule Cadet.Updater.XMLParser do
           |> Enum.map_join(" ", &stringify_error_message/1)
 
         "#{to_string(field)} #{formatted}"
-      end,
-      " "
+      end
     )
   end
 

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -62,15 +62,17 @@ defmodule Cadet.Updater.XMLParser do
 
   defp extract_changeset_error_message(errors_list) do
     errors_list
-    |> Enum.map(fn {field, messages} ->
-      formatted =
-        messages
-        |> List.wrap()
-        |> Enum.map_join(" ", &stringify_error_message/1)
+    |> Enum.map_join(
+      fn {field, messages} ->
+        formatted =
+          messages
+          |> List.wrap()
+          |> Enum.map_join(" ", &stringify_error_message/1)
 
-      "#{to_string(field)} #{formatted}"
-    end)
-    |> Enum.join(" ")
+        "#{to_string(field)} #{formatted}"
+      end,
+      " "
+    )
   end
 
   defp stringify_error_message(msg) when is_binary(msg), do: msg

--- a/lib/cadet_web/controllers/assessments_controller.ex
+++ b/lib/cadet_web/controllers/assessments_controller.ex
@@ -483,8 +483,25 @@ defmodule CadetWeb.AssessmentsController do
         end,
       Library:
         swagger_schema do
+          description(
+            "Discriminated library union. Fields depend on `format`. " <>
+              "`format=legacy`: chapter, variant, execTimeMs, globals, external, languageOptions. " <>
+              "`format=conductor`: language, evaluator (legacy fields must be absent)."
+          )
+
           properties do
-            chapter(:integer)
+            format(
+              :string,
+              "Library format discriminator",
+              enum: [:legacy, :conductor],
+              required: true
+            )
+
+            chapter(:integer, "Source language chapter (legacy only)")
+
+            variant(:string, "Source language variant (legacy only)")
+
+            execTimeMs(:integer, "Execution time in milliseconds (legacy only)")
 
             globals(
               Schema.new do
@@ -495,12 +512,32 @@ defmodule CadetWeb.AssessmentsController do
                     type(:string)
                   end
                 )
-              end
+              end,
+              "Map of global identifier to value (legacy only, serialized as array)"
             )
 
             external(
               Schema.ref(:ExternalLibrary),
-              "The external library for this question"
+              "The external library for this question (legacy only)"
+            )
+
+            languageOptions(
+              Schema.new do
+                type(:object)
+
+                additional_properties(true)
+              end,
+              "Language options key/value map (legacy only)"
+            )
+
+            language(
+              :string,
+              "Conductor language identifier (conductor only)"
+            )
+
+            evaluator(
+              :string,
+              "Conductor evaluator identifier (conductor only)"
             )
           end
         end,

--- a/lib/cadet_web/helpers/assessments_helpers.ex
+++ b/lib/cadet_web/helpers/assessments_helpers.ex
@@ -4,7 +4,25 @@ defmodule CadetWeb.AssessmentsHelpers do
   """
   import CadetWeb.ViewHelper
 
+  defp build_library(%{library: %{format: :conductor} = library}) do
+    %{
+      "format" => "conductor",
+      "language" => library.language,
+      "evaluator" => library.evaluator
+    }
+  end
+
+  defp build_library(%{library: %{format: :legacy} = library}) do
+    library
+    |> build_legacy_library_fields()
+    |> Map.put("format", "legacy")
+  end
+
   defp build_library(%{library: library}) do
+    build_library(%{library: Map.put(library, :format, :legacy)})
+  end
+
+  defp build_legacy_library_fields(library) do
     transform_map_for_view(library, %{
       chapter: :chapter,
       variant: :variant,

--- a/test/cadet/assessments/library_test.exs
+++ b/test/cadet/assessments/library_test.exs
@@ -102,5 +102,62 @@ defmodule Cadet.Assessments.LibraryTest do
       |> Map.delete(:external)
       |> assert_changeset(:valid)
     end
+
+    test "valid conductor library changeset" do
+      params = %{
+        format: :conductor,
+        language: "python-3",
+        evaluator: "lambda-pyeval-v1"
+      }
+
+      assert_changeset(params, :valid)
+    end
+
+    test "conductor without language is invalid" do
+      params = %{
+        format: :conductor,
+        evaluator: "lambda-pyeval-v1"
+      }
+
+      assert_changeset(params, :invalid)
+    end
+
+    test "conductor without evaluator is invalid" do
+      params = %{
+        format: :conductor,
+        language: "python-3"
+      }
+
+      assert_changeset(params, :invalid)
+    end
+
+    test "conductor with external is invalid", %{valid_params: legacy} do
+      params =
+        Map.merge(legacy, %{
+          format: :conductor,
+          language: "python-3",
+          evaluator: "lambda-pyeval-v1"
+        })
+
+      assert_changeset(params, :invalid)
+    end
+
+    test "legacy with language set is invalid", %{valid_params: params} do
+      params
+      |> Map.put(:language, "python-3")
+      |> assert_changeset(:invalid)
+    end
+
+    test "legacy with evaluator set is invalid", %{valid_params: params} do
+      params
+      |> Map.put(:evaluator, "lambda-pyeval-v1")
+      |> assert_changeset(:invalid)
+    end
+
+    test "legacy with explicit format is valid", %{valid_params: params} do
+      params
+      |> Map.put(:format, :legacy)
+      |> assert_changeset(:valid)
+    end
   end
 end

--- a/test/cadet/jobs/autograder/lambda_worker_test.exs
+++ b/test/cadet/jobs/autograder/lambda_worker_test.exs
@@ -270,5 +270,56 @@ defmodule Cadet.Autograder.LambdaWorkerTest do
                answer: Repo.get(Answer, answer.id)
              }) == expected
     end
+
+    test "it should build conductor params for a conductor grading library" do
+      question =
+        insert(
+          :programming_question,
+          %{
+            grading_library: build(:conductor_library),
+            question:
+              build(:programming_question_content, %{
+                public: [%{"score" => 1, "answer" => "1", "program" => "f(1);"}],
+                opaque: [],
+                secret: []
+              })
+          }
+        )
+
+      submission =
+        insert(:submission, %{
+          student: insert(:course_registration, %{role: :student}),
+          assessment: question.assessment
+        })
+
+      answer =
+        insert(:answer, %{
+          submission: submission,
+          question: question,
+          answer: %{code: "print(f(1))"}
+        })
+
+      question = Repo.get(Question, question.id)
+      answer = Repo.get(Answer, answer.id)
+
+      # The conductor request reuses the same programs/testcases as the legacy
+      # case but carries a (format, language, evaluator) library with none of the
+      # legacy chapter/external/globals fields.
+      expected = %{
+        prependProgram: question.question["prepend"],
+        postpendProgram: question.question["postpend"],
+        studentProgram: answer.answer["code"],
+        testcases:
+          question.question["public"] ++
+            question.question["opaque"] ++ question.question["secret"],
+        library: %{
+          format: "conductor",
+          language: question.grading_library.language,
+          evaluator: question.grading_library.evaluator
+        }
+      }
+
+      assert LambdaWorker.build_request_params(%{question: question, answer: answer}) == expected
+    end
   end
 end

--- a/test/cadet/updater/xml_parser_test.exs
+++ b/test/cadet/updater/xml_parser_test.exs
@@ -277,6 +277,170 @@ defmodule Cadet.Updater.XMLParserTest do
     end
   end
 
+  describe "Conductor programming language" do
+    test "happy path at TASK-level applies to all problems", %{
+      course: course,
+      assessments_with_config: assessments_with_config
+    } do
+      conductor =
+        build(:programming_question,
+          library: build(:conductor_library),
+          grading_library: build(:conductor_library)
+        )
+
+      for {assessment, assessment_config} <- assessments_with_config do
+        xml = XMLGenerator.generate_xml_for(assessment, [conductor])
+        assert :ok == XMLParser.parse_xml(xml, course.id, assessment_config.id)
+      end
+    end
+
+    test "happy path per-PROBLEM override", %{
+      course: course,
+      assessments_with_config: assessments_with_config
+    } do
+      conductor =
+        build(:programming_question,
+          library: build(:conductor_library),
+          grading_library: build(:conductor_library)
+        )
+
+      for {assessment, assessment_config} <- assessments_with_config do
+        xml = XMLGenerator.generate_xml_for(assessment, [conductor])
+        assert :ok == XMLParser.parse_xml(xml, course.id, assessment_config.id)
+      end
+    end
+
+    test "only language attribute (no evaluator) is invalid",
+         %{course: course, assessments_with_config: assessments_with_config} do
+      assert_conductor_error(
+        raw_conductor_problem(%{language: "python-3"}),
+        course,
+        assessments_with_config
+      )
+    end
+
+    test "only evaluator attribute (no language) is invalid",
+         %{course: course, assessments_with_config: assessments_with_config} do
+      assert_conductor_error(
+        raw_conductor_problem(%{evaluator: "lambda-pyeval-v1"}),
+        course,
+        assessments_with_config
+      )
+    end
+
+    test "language+evaluator mixed with interpreter is invalid",
+         %{course: course, assessments_with_config: assessments_with_config} do
+      assert_conductor_error(
+        raw_conductor_problem(%{
+          interpreter: 1,
+          language: "python-3",
+          evaluator: "lambda-pyeval-v1"
+        }),
+        course,
+        assessments_with_config
+      )
+    end
+
+    test "conductor with EXTERNAL child element is invalid",
+         %{course: course, assessments_with_config: assessments_with_config} do
+      assert_conductor_error(
+        raw_conductor_problem_with_children(
+          %{language: "python-3", evaluator: "lambda-pyeval-v1"},
+          ~s(<EXTERNAL name="runes"/>)
+        ),
+        course,
+        assessments_with_config
+      )
+    end
+
+    test "conductor with GLOBAL child element is invalid",
+         %{course: course, assessments_with_config: assessments_with_config} do
+      assert_conductor_error(
+        raw_conductor_problem_with_children(
+          %{language: "python-3", evaluator: "lambda-pyeval-v1"},
+          "<GLOBAL><IDENTIFIER>g</IDENTIFIER><VALUE>v</VALUE></GLOBAL>"
+        ),
+        course,
+        assessments_with_config
+      )
+    end
+
+    test "conductor with @variant is invalid",
+         %{course: course, assessments_with_config: assessments_with_config} do
+      assert_conductor_error(
+        raw_conductor_problem(%{language: "python-3", evaluator: "e1", variant: "typed"}),
+        course,
+        assessments_with_config
+      )
+    end
+
+    test "conductor with @exectime is invalid",
+         %{course: course, assessments_with_config: assessments_with_config} do
+      assert_conductor_error(
+        raw_conductor_problem(%{language: "python-3", evaluator: "e1", exectime: 2000}),
+        course,
+        assessments_with_config
+      )
+    end
+
+    test "empty PROGRAMMINGLANGUAGE element is invalid",
+         %{course: course, assessments_with_config: assessments_with_config} do
+      assert_conductor_error(raw_conductor_problem(%{}), course, assessments_with_config)
+    end
+
+    # Build a minimal XML document with a single PROBLEM containing a
+    # single PROGRAMMINGLANGUAGE element whose attribute map and (optional)
+    # inner children we control directly.
+    defp raw_conductor_problem(attrs) do
+      attrs_xml =
+        attrs
+        |> Enum.map(fn {k, v} -> ~s(#{k}="#{v}") end)
+        |> Enum.join(" ")
+
+      """
+      <CONTENT>
+        <TASK number="1" title="Conductor Test">
+          <PROBLEMS>
+            <PROBLEM type="programming" maxxp="100">
+              <TEXT>do something</TEXT>
+              <PROGRAMMINGLANGUAGE #{attrs_xml}/>
+            </PROBLEM>
+          </PROBLEMS>
+        </TASK>
+      </CONTENT>
+      """
+    end
+
+    defp raw_conductor_problem_with_children(attrs, inner_xml) do
+      attrs_xml =
+        attrs
+        |> Enum.map(fn {k, v} -> ~s(#{k}="#{v}") end)
+        |> Enum.join(" ")
+
+      """
+      <CONTENT>
+        <TASK number="1" title="Conductor Test">
+          <PROBLEMS>
+            <PROBLEM type="programming" maxxp="100">
+              <TEXT>do something</TEXT>
+              <PROGRAMMINGLANGUAGE #{attrs_xml}>#{inner_xml}</PROGRAMMINGLANGUAGE>
+            </PROBLEM>
+          </PROBLEMS>
+        </TASK>
+      </CONTENT>
+      """
+    end
+
+    defp assert_conductor_error(xml, course, assessments_with_config) do
+      for {_assessment, assessment_config} <- assessments_with_config do
+        assert capture_log(fn ->
+                 assert {:error, {:bad_request, _msg}} =
+                          XMLParser.parse_xml(xml, course.id, assessment_config.id)
+               end)
+      end
+    end
+  end
+
   describe "XML file processing" do
     test "happy path", %{
       questions: questions,

--- a/test/cadet/updater/xml_parser_test.exs
+++ b/test/cadet/updater/xml_parser_test.exs
@@ -394,8 +394,7 @@ defmodule Cadet.Updater.XMLParserTest do
     defp raw_conductor_problem(attrs) do
       attrs_xml =
         attrs
-        |> Enum.map(fn {k, v} -> ~s(#{k}="#{v}") end)
-        |> Enum.join(" ")
+        |> Enum.map_join(fn {k, v} -> ~s(#{k}="#{v}") end, " ")
 
       """
       <CONTENT>
@@ -414,8 +413,7 @@ defmodule Cadet.Updater.XMLParserTest do
     defp raw_conductor_problem_with_children(attrs, inner_xml) do
       attrs_xml =
         attrs
-        |> Enum.map(fn {k, v} -> ~s(#{k}="#{v}") end)
-        |> Enum.join(" ")
+        |> Enum.map_join(fn {k, v} -> ~s(#{k}="#{v}") end, " ")
 
       """
       <CONTENT>

--- a/test/cadet/updater/xml_parser_test.exs
+++ b/test/cadet/updater/xml_parser_test.exs
@@ -394,7 +394,7 @@ defmodule Cadet.Updater.XMLParserTest do
     defp raw_conductor_problem(attrs) do
       attrs_xml =
         attrs
-        |> Enum.map_join(fn {k, v} -> ~s(#{k}="#{v}") end, " ")
+        |> Enum.map_join(" ", fn {k, v} -> ~s(#{k}="#{v}") end)
 
       """
       <CONTENT>
@@ -413,7 +413,7 @@ defmodule Cadet.Updater.XMLParserTest do
     defp raw_conductor_problem_with_children(attrs, inner_xml) do
       attrs_xml =
         attrs
-        |> Enum.map_join(fn {k, v} -> ~s(#{k}="#{v}") end, " ")
+        |> Enum.map_join(" ", fn {k, v} -> ~s(#{k}="#{v}") end)
 
       """
       <CONTENT>

--- a/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
@@ -310,6 +310,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
+                      "format" => "legacy",
                       "variant" => &1.question.library.variant
                     },
                     "maxXp" => &1.question.max_xp,
@@ -355,6 +356,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
+                      "format" => "legacy",
                       "variant" => &1.question.library.variant
                     },
                     "maxXp" => &1.question.max_xp,
@@ -410,6 +412,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
+                      "format" => "legacy",
                       "variant" => &1.question.library.variant
                     },
                     "maxXp" => &1.question.max_xp,
@@ -1344,6 +1347,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
+                      "format" => "legacy",
                       "variant" => &1.question.library.variant
                     },
                     "maxXp" => &1.question.max_xp,
@@ -1389,6 +1393,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
+                      "format" => "legacy",
                       "variant" => &1.question.library.variant
                     },
                     "content" => &1.question.question.content,
@@ -1444,6 +1449,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
+                      "format" => "legacy",
                       "variant" => &1.question.library.variant
                     },
                     "maxXp" => &1.question.max_xp,

--- a/test/factories/assessments/library_factory.ex
+++ b/test/factories/assessments/library_factory.ex
@@ -9,6 +9,7 @@ defmodule Cadet.Assessments.LibraryFactory do
 
       def library_factory do
         %{
+          format: :legacy,
           chapter: Enum.random(1..4),
           globals:
             Enum.reduce(
@@ -17,6 +18,15 @@ defmodule Cadet.Assessments.LibraryFactory do
               fn _, acc -> Map.put(acc, Faker.Lorem.word(), Faker.Lorem.sentence()) end
             ),
           external: build(:external_library)
+        }
+      end
+
+      def conductor_library_factory do
+        %{
+          format: :conductor,
+          language: Enum.random(~w(python-3 python-3-11 javascript node-20 ruby-3)),
+          evaluator:
+            Enum.random(~w(lambda-pyeval-v1 lambda-pyeval-v2 lambda-jseval-v1 lambda-rbeval-v1))
         }
       end
 

--- a/test/support/xml_generator.ex
+++ b/test/support/xml_generator.ex
@@ -175,11 +175,13 @@ defmodule Cadet.Test.XMLGenerator do
   end
 
   defp programminglanguage(raw_attrs, children) do
-    {"PROGRAMMINGLANGUAGE", map_permit_keys(raw_attrs, ~w(interpreter)a), children}
+    {"PROGRAMMINGLANGUAGE",
+     map_permit_keys(raw_attrs, ~w(interpreter variant exectime language evaluator)a), children}
   end
 
   defp graderprogramminglanguage(raw_attrs, children) do
-    {"GRADERPROGRAMMINGLANGUAGE", map_permit_keys(raw_attrs, ~w(interpreter)a), children}
+    {"GRADERPROGRAMMINGLANGUAGE",
+     map_permit_keys(raw_attrs, ~w(interpreter variant exectime language evaluator)a), children}
   end
 
   defp external(raw_attrs, children) do
@@ -211,18 +213,42 @@ defmodule Cadet.Test.XMLGenerator do
     if no_deployment do
       []
     else
-      [
-        tag_function.(
-          %{interpreter: library.chapter},
-          [
-            external(
-              %{name: library.external.name},
-              Enum.map(library.external.symbols, &symbol/1)
-            )
-          ] ++ process_globals(library[:globals])
-        )
-      ]
+      tag_function.(
+        library_attrs(library),
+        library_children(library)
+      )
+      |> List.wrap()
     end
+  end
+
+  defp library_attrs(%{format: :conductor} = library) do
+    Map.take(library, [:language, :evaluator, :variant, :exectime, :interpreter])
+    |> Map.reject(fn {_k, v} -> is_nil(v) end)
+  end
+
+  defp library_attrs(library) do
+    %{interpreter: library.chapter}
+  end
+
+  defp library_children(%{format: :conductor}), do: []
+
+  defp library_children(library) do
+    [
+      external(
+        %{name: library.external.name},
+        Enum.map(library.external.symbols, &symbol/1)
+      )
+    ] ++ process_globals(library[:globals])
+  end
+
+  # Allows tests to build a raw XML snippet that intentionally violates
+  # the conductor/legacy rules.
+  def raw_programminglanguage(attrs, children \\ []) do
+    {"PROGRAMMINGLANGUAGE", attrs, children}
+  end
+
+  def raw_graderprogramminglanguage(attrs, children \\ []) do
+    {"GRADERPROGRAMMINGLANGUAGE", attrs, children}
   end
 
   defp process_globals(nil) do

--- a/test/support/xml_generator.ex
+++ b/test/support/xml_generator.ex
@@ -213,16 +213,18 @@ defmodule Cadet.Test.XMLGenerator do
     if no_deployment do
       []
     else
-      tag_function.(
-        library_attrs(library),
-        library_children(library)
+      List.wrap(
+        tag_function.(
+          library_attrs(library),
+          library_children(library)
+        )
       )
-      |> List.wrap()
     end
   end
 
-  defp library_attrs(%{format: :conductor} = library) do
-    Map.take(library, [:language, :evaluator, :variant, :exectime, :interpreter])
+  defp library_attrs(library = %{format: :conductor}) do
+    library
+    |> Map.take([:language, :evaluator, :variant, :exectime, :interpreter])
     |> Map.reject(fn {_k, v} -> is_nil(v) end)
   end
 


### PR DESCRIPTION
Adding support for conductor (external runtime) assessments with XOR constraint for backwards compatibility

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #1368 
- <kbd>&nbsp;2&nbsp;</kbd> #1367 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1363 
<!-- GitButler Footer Boundary Bottom -->