### PR TITLE
Add hardened mode restricting course creation to super admins

### DIFF
--- a/config/cadet.exs.example
+++ b/config/cadet.exs.example
@@ -152,6 +152,9 @@ config :cadet,
 # config :cadet, Cadet.Jobs.Scheduler,
 #   timezone: "Asia/Singapore",
 
+# Hardened mode: when true, only super admins may create courses.
+# config :cadet, hardened_mode: true
+
 # # Additional configuration for SAML authentication
 # # For more details, see https://github.com/handnot2/samly
 # config :samly, Samly.Provider,

--- a/config/cadet.exs.example
+++ b/config/cadet.exs.example
@@ -152,8 +152,8 @@ config :cadet,
 # config :cadet, Cadet.Jobs.Scheduler,
 #   timezone: "Asia/Singapore",
 
-# Hardened mode: when true, only super admins may create courses.
-# config :cadet, hardened_mode: true
+# When true, only super admins may create courses.
+# config :cadet, restrict_course_creation: true
 
 # # Additional configuration for SAML authentication
 # # For more details, see https://github.com/handnot2/samly

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,6 +11,9 @@ config :cadet, environment: Mix.env()
 config :cadet,
   ecto_repos: [Cadet.Repo]
 
+# Hardened mode: when true, only super admins may create courses.
+config :cadet, hardened_mode: false
+
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
 # Scheduler, e.g. for CS1101S

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,8 +11,8 @@ config :cadet, environment: Mix.env()
 config :cadet,
   ecto_repos: [Cadet.Repo]
 
-# Hardened mode: when true, only super admins may create courses.
-config :cadet, hardened_mode: false
+# When true, only super admins may create courses.
+config :cadet, restrict_course_creation: false
 
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 

--- a/lib/cadet/env.ex
+++ b/lib/cadet/env.ex
@@ -12,11 +12,10 @@ defmodule Cadet.Env do
   end
 
   @doc """
-  Returns whether hardened mode is enabled. Under hardened mode, course
-  creation is restricted to super admins.
+  Returns whether course creation is restricted to super admins.
   """
-  @spec hardened_mode? :: boolean()
-  def hardened_mode? do
-    Application.get_env(:cadet, :hardened_mode, false)
+  @spec restrict_course_creation? :: boolean()
+  def restrict_course_creation? do
+    Application.get_env(:cadet, :restrict_course_creation, false)
   end
 end

--- a/lib/cadet/env.ex
+++ b/lib/cadet/env.ex
@@ -10,4 +10,13 @@ defmodule Cadet.Env do
   def env do
     Application.get_env(:cadet, :environment)
   end
+
+  @doc """
+  Returns whether hardened mode is enabled. Under hardened mode, course
+  creation is restricted to super admins.
+  """
+  @spec hardened_mode? :: boolean()
+  def hardened_mode? do
+    Application.get_env(:cadet, :hardened_mode, false)
+  end
 end

--- a/lib/cadet/env.ex
+++ b/lib/cadet/env.ex
@@ -16,6 +16,6 @@ defmodule Cadet.Env do
   """
   @spec restrict_course_creation? :: boolean()
   def restrict_course_creation? do
-    Application.get_env(:cadet, :restrict_course_creation, false)
+    Application.get_env(:cadet, :restrict_course_creation)
   end
 end

--- a/lib/cadet_web/controllers/courses_controller.ex
+++ b/lib/cadet_web/controllers/courses_controller.ex
@@ -37,25 +37,37 @@ defmodule CadetWeb.CoursesController do
 
     params = params |> to_snake_case_atom_keys()
 
-    if user.super_admin or CourseRegistrations.get_admin_courses_count(user) < 5 do
-      case Courses.create_course_config(params, user) do
-        {:ok, course} ->
-          Logger.info("Successfully created course #{course.id} for user #{user.id}.")
-          text(conn, "OK")
+    cond do
+      Cadet.Env.hardened_mode?() and not user.super_admin ->
+        Logger.error(
+          "Rejected course creation by user #{user.id}: hardened mode restricts creation to super admins."
+        )
 
-        {:error, _, _, _} ->
-          Logger.error("Invalid parameters provided by user #{user.id} while creating a course.")
+        # Opaque 401 — identical to Cadet.Auth.ErrorHandler, does not disclose the restriction.
+        send_resp(conn, 401, "Unauthorised")
 
-          conn
-          |> put_status(:bad_request)
-          |> text("Invalid parameter(s)")
-      end
-    else
-      Logger.error("User #{user.id} has exceeded the limit of 5 admin courses.")
+      user.super_admin or CourseRegistrations.get_admin_courses_count(user) < 5 ->
+        case Courses.create_course_config(params, user) do
+          {:ok, course} ->
+            Logger.info("Successfully created course #{course.id} for user #{user.id}.")
+            text(conn, "OK")
 
-      conn
-      |> put_status(:forbidden)
-      |> text("User not allowed to be admin of more than 5 courses.")
+          {:error, _, _, _} ->
+            Logger.error(
+              "Invalid parameters provided by user #{user.id} while creating a course."
+            )
+
+            conn
+            |> put_status(:bad_request)
+            |> text("Invalid parameter(s)")
+        end
+
+      true ->
+        Logger.error("User #{user.id} has exceeded the limit of 5 admin courses.")
+
+        conn
+        |> put_status(:forbidden)
+        |> text("User not allowed to be admin of more than 5 courses.")
     end
   end
 

--- a/lib/cadet_web/controllers/courses_controller.ex
+++ b/lib/cadet_web/controllers/courses_controller.ex
@@ -43,8 +43,10 @@ defmodule CadetWeb.CoursesController do
           "Rejected course creation by user #{user.id}: course creation is restricted to super admins."
         )
 
-        # Opaque 401 — identical to Cadet.Auth.ErrorHandler, does not disclose the restriction.
-        send_resp(conn, 401, "Unauthorised")
+        # Opaque 403 — generic "Forbidden" body, does not disclose the restriction.
+        conn
+        |> put_status(:forbidden)
+        |> text("Forbidden")
 
       user.super_admin or CourseRegistrations.get_admin_courses_count(user) < 5 ->
         case Courses.create_course_config(params, user) do

--- a/lib/cadet_web/controllers/courses_controller.ex
+++ b/lib/cadet_web/controllers/courses_controller.ex
@@ -38,9 +38,9 @@ defmodule CadetWeb.CoursesController do
     params = params |> to_snake_case_atom_keys()
 
     cond do
-      Cadet.Env.hardened_mode?() and not user.super_admin ->
+      Cadet.Env.restrict_course_creation?() and not user.super_admin ->
         Logger.error(
-          "Rejected course creation by user #{user.id}: hardened mode restricts creation to super admins."
+          "Rejected course creation by user #{user.id}: course creation is restricted to super admins."
         )
 
         # Opaque 401 — identical to Cadet.Auth.ErrorHandler, does not disclose the restriction.

--- a/test/cadet_web/controllers/courses_controller_test.exs
+++ b/test/cadet_web/controllers/courses_controller_test.exs
@@ -140,10 +140,12 @@ defmodule CadetWeb.CoursesControllerTest do
     end
 
     @tag authenticate: :student
-    test "under hardened mode, non-super-admin is rejected with an opaque 401", %{conn: conn} do
-      original = Application.get_env(:cadet, :hardened_mode, false)
-      Application.put_env(:cadet, :hardened_mode, true)
-      on_exit(fn -> Application.put_env(:cadet, :hardened_mode, original) end)
+    test "when course creation is restricted, non-super-admin is rejected with opaque 401", %{
+      conn: conn
+    } do
+      original = Application.get_env(:cadet, :restrict_course_creation, false)
+      Application.put_env(:cadet, :restrict_course_creation, true)
+      on_exit(fn -> Application.put_env(:cadet, :restrict_course_creation, original) end)
 
       user = conn.assigns.current_user
       assert CourseRegistration |> where(user_id: ^user.id) |> Repo.all() |> length() == 1
@@ -173,10 +175,10 @@ defmodule CadetWeb.CoursesControllerTest do
     end
 
     @tag authenticate: :student
-    test "under hardened mode, super admin can create a course", %{conn: conn} do
-      original = Application.get_env(:cadet, :hardened_mode, false)
-      Application.put_env(:cadet, :hardened_mode, true)
-      on_exit(fn -> Application.put_env(:cadet, :hardened_mode, original) end)
+    test "when course creation is restricted, super admin can create a course", %{conn: conn} do
+      original = Application.get_env(:cadet, :restrict_course_creation, false)
+      Application.put_env(:cadet, :restrict_course_creation, true)
+      on_exit(fn -> Application.put_env(:cadet, :restrict_course_creation, original) end)
 
       user = conn.assigns.current_user
       {:ok, user} = user |> User.changeset(%{super_admin: true}) |> Repo.update()

--- a/test/cadet_web/controllers/courses_controller_test.exs
+++ b/test/cadet_web/controllers/courses_controller_test.exs
@@ -140,7 +140,7 @@ defmodule CadetWeb.CoursesControllerTest do
     end
 
     @tag authenticate: :student
-    test "when course creation is restricted, non-super-admin is rejected with opaque 401", %{
+    test "when course creation is restricted, non-super-admin is rejected with opaque 403", %{
       conn: conn
     } do
       original = Application.get_env(:cadet, :restrict_course_creation, false)
@@ -169,7 +169,7 @@ defmodule CadetWeb.CoursesControllerTest do
 
       resp = post(conn, build_url_create(), params)
 
-      assert response(resp, 401) == "Unauthorised"
+      assert response(resp, 403) == "Forbidden"
       # no course should have been created
       assert CourseRegistration |> where(user_id: ^user.id) |> Repo.all() |> length() == 1
     end

--- a/test/cadet_web/controllers/courses_controller_test.exs
+++ b/test/cadet_web/controllers/courses_controller_test.exs
@@ -138,6 +138,71 @@ defmodule CadetWeb.CoursesControllerTest do
       assert response(resp, 200) == "OK"
       assert CourseRegistration |> where(user_id: ^user.id) |> Repo.all() |> length() == 7
     end
+
+    @tag authenticate: :student
+    test "under hardened mode, non-super-admin is rejected with an opaque 401", %{conn: conn} do
+      original = Application.get_env(:cadet, :hardened_mode, false)
+      Application.put_env(:cadet, :hardened_mode, true)
+      on_exit(fn -> Application.put_env(:cadet, :hardened_mode, original) end)
+
+      user = conn.assigns.current_user
+      assert CourseRegistration |> where(user_id: ^user.id) |> Repo.all() |> length() == 1
+
+      params = %{
+        "course_name" => "CS1101S Programming Methodology (AY20/21 Sem 1)",
+        "course_short_name" => "CS1101S",
+        "viewable" => "true",
+        "enable_game" => "true",
+        "enable_achievements" => "true",
+        "enable_overall_leaderboard" => "true",
+        "enable_contest_leaderboard" => "true",
+        "top_leaderboard_display" => "100",
+        "top_contest_leaderboard_display" => "10",
+        "enable_sourcecast" => "true",
+        "enable_stories" => "true",
+        "source_chapter" => "1",
+        "source_variant" => "default",
+        "module_help_text" => "Help Text"
+      }
+
+      resp = post(conn, build_url_create(), params)
+
+      assert response(resp, 401) == "Unauthorised"
+      # no course should have been created
+      assert CourseRegistration |> where(user_id: ^user.id) |> Repo.all() |> length() == 1
+    end
+
+    @tag authenticate: :student
+    test "under hardened mode, super admin can create a course", %{conn: conn} do
+      original = Application.get_env(:cadet, :hardened_mode, false)
+      Application.put_env(:cadet, :hardened_mode, true)
+      on_exit(fn -> Application.put_env(:cadet, :hardened_mode, original) end)
+
+      user = conn.assigns.current_user
+      {:ok, user} = user |> User.changeset(%{super_admin: true}) |> Repo.update()
+
+      params = %{
+        "course_name" => "CS1101S Programming Methodology (AY20/21 Sem 1)",
+        "course_short_name" => "CS1101S",
+        "viewable" => "true",
+        "enable_game" => "true",
+        "enable_achievements" => "true",
+        "enable_overall_leaderboard" => "true",
+        "enable_contest_leaderboard" => "true",
+        "top_leaderboard_display" => "100",
+        "top_contest_leaderboard_display" => "10",
+        "enable_sourcecast" => "true",
+        "enable_stories" => "true",
+        "source_chapter" => "1",
+        "source_variant" => "default",
+        "module_help_text" => "Help Text"
+      }
+
+      resp = post(conn, build_url_create(), params)
+
+      assert response(resp, 200) == "OK"
+      assert CourseRegistration |> where(user_id: ^user.id) |> Repo.all() |> length() == 2
+    end
   end
 
   describe "GET /v2/courses/course_id/config, unauthenticated" do


### PR DESCRIPTION
## Summary

Adds a config-driven flag that restricts course creation (`POST /v2/config/create`) to global super admins.

When enabled, any non-super-admin attempting to create a course receives an **opaque `403 "Forbidden"`** — the same generic body the router's authz plug returns — so the restriction is not disclosed to the client. The real reason is logged server-side only. The flag defaults to **off**, so existing behaviour is unchanged unless explicitly enabled. **No frontend changes required.**

## Configuration

Opt-in via `config/` files:

```elixir
config :cadet, restrict_course_creation: true
```

Read through the new `Cadet.Env.restrict_course_creation?/0` helper; documented for prod runtime in `config/cadet.exs.example`.

## Changes

- `config/config.exs` — declare `restrict_course_creation` flag (default `false`)
- `lib/cadet/env.ex` — add `Cadet.Env.restrict_course_creation?/0`
- `lib/cadet_web/controllers/courses_controller.ex` — enforce in `create/2`
- `config/cadet.exs.example` — document the prod runtime option
- `test/cadet_web/controllers/courses_controller_test.exs` — cover super-admin success and non-super-admin opaque 403

## Testing

- `mix test test/cadet_web/controllers/courses_controller_test.exs` → **11 tests, 0 failures** (9 existing + 2 new)
- `mix format --check-formatted` → clean
- `mix credo` → no issues on changed source

## Notes

Rejections return **403 Forbidden** with a generic, opaque body — consistent with the sibling too-many-courses branch and the router's role-based rejections. (An earlier revision used 401, but that would incorrectly trigger the frontend's token-refresh flow.)